### PR TITLE
Add Desktop Entry.

### DIFF
--- a/Kristall.desktop
+++ b/Kristall.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Kristall
+GenericName=Kristall
+Comment=Graphical gemini client
+Categories=Network;
+Icon=kristall
+Exec=kristall %u
+Terminal=false
+Type=Application
+MimeType=x-scheme-handler/gemini;x-scheme-handler/gopher;x-scheme-handler/finger;


### PR DESCRIPTION
See <https://specifications.freedesktop.org/desktop-entry-spec/latest/>.


----

I don't know anything about qmake, so I didn't add the rules.

`Kristall.desktop` has to be installed into `/usr/share/applications/` and
`src/icons/kristall.svg` has to be installed into `/usr/share/pixmaps/` on
Linux.