### PR TITLE
Windows (MSVC) build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,17 @@ make
 
 #### Windows
 
-Just use QtCreator to build `./src/kristall.pro`. Default settings should be fine.
+Compile OpenSSL with the following steps:  
+- Install [Perl](https://www.perl.org/get.html) (either ActiveState or Strawberry)
+- Install [NASM](https://www.nasm.us/)
+- Add both to your PATH
+- Clone [OpenSSL](https://github.com/openssl/openssl)
+- Open a Visual Studio Developer Command Prompt (or a command prompt that has ran vcvarsall.bat). You will need Administrator privileges for the install step
+- In the OpenSSL root directory, run `perl Configure VC-WIN32` if compiling for 32 bit, `perl Configure VC-WIN64A` for 64 bit
+- Run `nmake`
+- Run `nmake install` to install OpenSSL in `C:\Program Files\OpenSSL`
+
+Use QtCreator to build `./src/kristall.pro` with default settings.
 
 #### MacOS X
 

--- a/src/certificateselectiondialog.cpp
+++ b/src/certificateselectiondialog.cpp
@@ -68,7 +68,7 @@ void CertificateSelectionDialog::acceptTemporaryWithTimeout(QDateTime timeout)
     std::default_random_engine rng;
     rng.seed(QDateTime::currentDateTime().toMSecsSinceEpoch());
 
-    std::uniform_int_distribution<char> distr;
+    std::uniform_int_distribution<int> distr(0, 255);
 
     char items[8];
     for(auto & c : items) {

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -7,6 +7,7 @@
 #include <QCryptographicHash>
 #include <QDebug>
 
+#include <array>
 #include <cmath>
 
 static QString encodeCssFont (const QFont& refFont)

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -15,10 +15,14 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-QMAKE_CFLAGS += -Wno-unused-parameter
-QMAKE_CXXFLAGS += -Wno-unused-parameter
-
 LIBS += -lcrypto
+win32-msvc {
+    QMAKE_CFLAGS += /permissive-
+    QMAKE_CXXFLAGS += /permissive-
+    LIBS -= -lcrypto
+    LIBS += "C:\Program Files\OpenSSL\lib\libcrypto.lib"
+    INCLUDEPATH += "C:\Program Files\OpenSSL\include"
+}
 
 INCLUDEPATH += $$PWD/../lib/luis-l-gist/
 DEPENDPATH += $$PWD/../lib/luis-l-gist/

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -16,7 +16,13 @@ DEFINES += QT_DEPRECATED_WARNINGS
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 LIBS += -lcrypto
+QMAKE_CFLAGS += -Wno-unused-parameter
+QMAKE_CXXFLAGS += -Wno-unused-parameter
+
 win32-msvc {
+    QMAKE_CFLAGS -= -Wno-unused-parameter
+    QMAKE_CXXFLAGS -= -Wno-unused-parameter
+
     QMAKE_CFLAGS += /permissive-
     QMAKE_CXXFLAGS += /permissive-
     LIBS -= -lcrypto


### PR DESCRIPTION
Assumes a working OpenSSL install at `C:\Program Files\OpenSSL`  
`win32-msvc` encapsulates both 32 and 64 bit msvc builds.