### PR TITLE
adds sourcefiles as dependency to build task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ sharedir=$(DESTDIR)$(PREFIX)/share
 kristall: build/kristall
 	cp build/kristall $@
 
-build/kristall:
+build/kristall: src/*
 	mkdir -p build
 	cd build && qmake ../src/kristall.pro && $(MAKE)
 


### PR DESCRIPTION
Monitoring the modified state of source files for the build task means
that simply running 'make' will detect if a rebuild is actually needed
or not. Currently if the build file exists make is not run again. A
clean must be run first, then make. This is an improvement on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masterq32/kristall/8)
<!-- Reviewable:end -->
