### PR TITLE
Update desktop entry install instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -86,7 +86,8 @@ Use the `Makefile` to build `build/kristall` instead of the default target. Ther
 
 The provided desktop file can be installed into the local system
 ```sh
-ln -s Kristall.desktop ~/.local/share/applications/kristall.desktop
+cp Kristall.desktop ~/.local/share/applications/kristall.desktop
+update-desktop-database ~/.local/share/applications
 ```
 
 ### Haiku


### PR DESCRIPTION
- Copying is more robust then the symlink, and I had issues with my system finding the file with a symlink
- Using `update-desktop-database` ensures it will appear in menus, etc