### PR TITLE
Updated info for Arch linux

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -49,8 +49,9 @@ These notes are probably also correct for Debian (someone please verify)
 
 #### Notes for Manjaro/Arch
 - Required packages
-  - `qt5`
+  - `qt5-base`
   - `qt5-multimedia`
+  - `qt5-svg`
   - `openssl` or `libressl`
 
 #### Notes on void linux


### PR DESCRIPTION
`qt5-svg` added per this comment: https://aur.archlinux.org/packages/kristall/#comment-753212
Added `-base` to give the `qt` package it's accurate name.