### PR TITLE
Set a Variable QMAKE in the makefile to direct build on Fedora 32, wh…

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -47,6 +47,23 @@ Unsupported Versions: 16.04
 
 These notes are probably also correct for Debian (someone please verify)
 
+#### Notes for Fedora 32 (and probably other recent versions)
+In the small `Makefile` mentioned above, comment out the line:
+
+* `QMAKE_COMMAND := qmake`
+
+And uncomment the line:
+* `# QMAKE_COMMAND := /usr/bin/qmake-qt5`
+
+This is because Fedora has a different naming scheme for the qmake executable. 
+
+- Key required packages
+    - `qt5-qtbase`
+    - `qt5-qtbase-devel`
+	- `ccache-3.7.7-1.fc32.x86_64`
+	- `make`
+	- And the packages they depend on
+
 #### Notes for Manjaro/Arch
 - Required packages
   - `qt5-base`

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,14 @@ INSTALL_DATA=$(INSTALL) -m 644
 # Directories into which to install the various files
 bindir=$(DESTDIR)$(PREFIX)/bin
 sharedir=$(DESTDIR)$(PREFIX)/share
+QMAKE := /usr/bin/qmake-qt5
 
 kristall: build/kristall
 	cp build/kristall $@
 
 build/kristall: src/*
 	mkdir -p build
-	cd build && qmake ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
+	cd build && $(QMAKE) ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
 
 install: kristall
 	# Create target directories

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,19 @@ INSTALL_DATA=$(INSTALL) -m 644
 # Directories into which to install the various files
 bindir=$(DESTDIR)$(PREFIX)/bin
 sharedir=$(DESTDIR)$(PREFIX)/share
-QMAKE := /usr/bin/qmake-qt5
+
+# Default Qmake Command For Ubuntu (and probably other Debian) distributions
+
+QMAKE_COMMAND := qmake
+# For Fedora 32 and similar distributions, use the next line instead of the above.
+# QMAKE_COMMAND := /usr/bin/qmake-qt5
 
 kristall: build/kristall
 	cp build/kristall $@
 
 build/kristall: src/*
 	mkdir -p build
-	cd build && $(QMAKE) ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
+	cd build && $(QMAKE_COMMAND) ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
 
 install: kristall
 	# Create target directories


### PR DESCRIPTION
Set a Variable QMAKE in the makefile to direct build on Fedora 32, where 'qmake' doesn't exist, but qmake-qt5 (and qmake-qt4) does.