### PR TITLE
Pass -D flag to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ PREFIX?=/usr/local
 # What to run to install various files
 INSTALL?=install
 # Run to install the actual binary
-INSTALL_PROGRAM=$(INSTALL) -m 755
+INSTALL_PROGRAM=$(INSTALL) -Dm 755
 # Run to install application data, with differing permissions
-INSTALL_DATA=$(INSTALL) -m 644
+INSTALL_DATA=$(INSTALL) -Dm 644
 
 # Directories into which to install the various files
 bindir=$(DESTDIR)$(PREFIX)/bin
@@ -20,13 +20,6 @@ build/kristall: src/*
 	cd build && qmake ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
 
 install: kristall
-	# Create target directories
-	mkdir -p $(sharedir)/icons/hicolor/scalable/apps/
-	mkdir -p $(sharedir)/icons/hicolor/16x16/apps/
-	mkdir -p $(sharedir)/icons/hicolor/32x32/apps/
-	mkdir -p $(sharedir)/icons/hicolor/64x64/apps/
-	mkdir -p $(sharedir)/icons/hicolor/128x128/apps/
-	mkdir -p $(sharedir)/applications/
 	# Install icons
 	$(INSTALL_DATA) src/icons/kristall.svg $(sharedir)/icons/hicolor/scalable/apps/net.random-projects.kristall.svg
 	$(INSTALL_DATA) src/icons/kristall-16.png $(sharedir)/icons/hicolor/16x16/apps/net.random-projects.kristall.png


### PR DESCRIPTION
This causes install to create directories in the install path if they do not already exist.

I needed to set `INSTALL="install -D"` while packaging for void as it is installed to an empty directory (See https://github.com/void-linux/void-packages/pull/23336)