### PR TITLE
Add focus on URL bar when new tab opens

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -99,6 +99,8 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
         tab->navigateTo(QUrl("about:blank"), BrowserTab::DontPush);
     }
 
+    tab->focusUrlBar();
+
     return tab;
 }
 


### PR DESCRIPTION
Currently if you use ctrl-T (cmd-T on Mac) to open a new tab, you have to manually put focus on the URL bar either with the mouse or ctrl-L. Automatically giving focus to the URL bar when a user opens a new tab is consistent with what they would expect from other graphical browsers (Chrome, Safari, etc.) and allows them to start typing an address right away.