### PR TITLE
Add back and forward context menu options

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1135,6 +1135,18 @@ void BrowserTab::on_text_browser_customContextMenuRequested(const QPoint &pos)
         menu.addSeparator();
     }
 
+    QAction * back = menu.addAction("Back");
+    connect(back, &QAction::triggered, [this]() {
+        this->on_back_button_clicked();
+    });
+
+    QAction * forward = menu.addAction("Forward");
+    connect(forward, &QAction::triggered, [this]() {
+        this->on_forward_button_clicked();
+    });
+
+    menu.addSeparator();
+
     connect(menu.addAction("Select all"), &QAction::triggered, [this]() {
         this->ui->text_browser->selectAll();
     });


### PR DESCRIPTION
This adds "Back" and "Forward" options to the right-click context
menu. This makes it easier to navigate back and forth among pages
without having to navigate the mouse to the upper-left corner
each time.

Signed-off-by: Steve Winslow <steve@swinslow.net>