### PR TITLE
Markdown Outline generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ endif
 kristall: build/kristall
 	cp build/kristall $@
 
+.PHONY: build/kristall
 build/kristall: src/*
 	mkdir -p build
 	cd build; $(HOMEBREW_PATH) $(QMAKE_COMMAND) ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)

--- a/src/renderers/markdownrenderer.cpp
+++ b/src/renderers/markdownrenderer.cpp
@@ -196,10 +196,11 @@ static void renderNode(RenderState &state, cmark_node & node, QTextCharFormat cu
         default: qDebug() << "heading" << cmark_node_get_heading_level(&node); break;
         }
 
+	auto text = cmark_node_get_literal(cmark_node_first_child(&node));
         switch(cmark_node_get_heading_level(&node)) {
-        case 1: state.outline->appendH1("Unknown H1", QString { }); break;
-        case 2: state.outline->appendH2("Unknown H2", QString { }); break;
-        case 3: state.outline->appendH3("Unknown H3", QString { }); break;
+        case 1: state.outline->appendH1(text, QString { }); break;
+        case 2: state.outline->appendH2(text, QString { }); break;
+        case 3: state.outline->appendH3(text, QString { }); break;
         }
 
         renderChildren(state, node, fmt);


### PR DESCRIPTION
Initial support for outline generation in markdown.

It has problems when formatting is applied to headings (like
```markdown
# Hello *kristall*
```
would show only hello).  Do you know how to get the full unformatted text?

Thanks

The first commit adds ".PHONY" to the build so that running make after a change will actually rebuild missing parts