### PR TITLE
gemini: respect sensitive input (status 11)

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -618,7 +618,7 @@ File Size: %2
     this->updateUI();
 }
 
-void BrowserTab::on_inputRequired(const QString &query)
+void BrowserTab::on_inputRequired(const QString &query, const bool is_sensitive)
 {
     this->network_timeout_timer.stop();
 
@@ -626,6 +626,7 @@ void BrowserTab::on_inputRequired(const QString &query)
 
     dialog.setInputMode(QInputDialog::TextInput);
     dialog.setLabelText(query);
+    if (is_sensitive) dialog.setTextEchoMode(QLineEdit::Password);
 
     while(true)
     {

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -116,7 +116,7 @@ private: // network slots
     void on_requestProgress(qint64 transferred);
     void on_requestComplete(QByteArray const & data, QString const & mime);
     void on_redirected(QUrl const & uri, bool is_permanent);
-    void on_inputRequired(QString const & user_query);
+    void on_inputRequired(QString const & user_query, bool is_sensitive);
     void on_networkError(ProtocolHandler::NetworkError error, QString const & reason);
     void on_certificateRequired(QString const & info);
     void on_hostCertificateLoaded(QSslCertificate const & cert);

--- a/src/protocolhandler.hpp
+++ b/src/protocolhandler.hpp
@@ -54,7 +54,7 @@ signals:
     void redirected(QUrl const & uri, bool is_permanent);
 
     //! The server needs some information from the user to process this query.
-    void inputRequired(QString const & user_query);
+    void inputRequired(QString const & user_query, bool is_sensitive);
 
     //! There was an error while processing the request
     void networkError(NetworkError error, QString const & reason);

--- a/src/protocols/geminiclient.cpp
+++ b/src/protocols/geminiclient.cpp
@@ -208,7 +208,14 @@ void GeminiClient::socketReadyRead()
                 switch(primary_code)
                 {
                 case 1: // requesting input
-                    emit inputRequired(meta);
+		    switch (secondary_code) {
+		    case 1:
+		      emit inputRequired(meta, true);
+		      break;
+		    case 0:
+		    default:
+		      emit inputRequired(meta, false);
+		    }
                     return;
 
                 case 2: // success


### PR DESCRIPTION
I noticed that sensitive input prompt (11) was like normal input (10)

According to specs, it's enough to hide input text
> but the user's input should not be echoed to the screen to prevent it being read by "shoulder surfers"

I choose QLineEdit::Password, but other options are available: QLineEdit::NoEcho and PasswordEchoOnEdit.  Maybe it is something the user want to configure?