### PR TITLE
Fix link to license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,4 @@ See [ROADMAP.md](ROADMAP.md)
 ## License
 
 Kristall is released under the GPLv3 or (at your option) any later version.
-[See LICENCE as well](LICENCE)
-[See LICENCE as well](LICENCE)
+[See LICENSE as well](LICENSE)


### PR DESCRIPTION
The README link to the LICENSE file spelled it as "LICENCE", 
resulting in a broken link. This corrects the spelling to match the
existing filename.

Signed-off-by: Steve Winslow <steve@swinslow.net>