### PR TITLE
Allow to open local files without speciyfing the 'file:' schema from the CLI

### DIFF
--- a/Kristall.desktop
+++ b/Kristall.desktop
@@ -7,4 +7,4 @@ Icon=net.random-projects.kristall
 Exec=kristall %u
 Terminal=false
 Type=Application
-MimeType=x-scheme-handler/gemini;x-scheme-handler/gopher;x-scheme-handler/finger;
+MimeType=x-scheme-handler/gemini;x-scheme-handler/gopher;x-scheme-handler/finger;text/gemini;text/markdown;text/x-kristall-theme;

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ install: kristall
 	$(MAKEDIR) $(sharedir)/icons/hicolor/64x64/apps/
 	$(MAKEDIR) $(sharedir)/icons/hicolor/128x128/apps/
 	$(MAKEDIR) $(sharedir)/applications/
+	$(MAKEDIR) $(sharedir)/mime/packages/
 	$(MAKEDIR) $(bindir)
   
 	# Install files
@@ -50,6 +51,7 @@ install: kristall
 	$(INSTALL_DATA) src/icons/kristall-64.png $(sharedir)/icons/hicolor/64x64/apps/net.random-projects.kristall.png
 	$(INSTALL_DATA) src/icons/kristall-128.png $(sharedir)/icons/hicolor/128x128/apps/net.random-projects.kristall.png
 	$(INSTALL_DATA) Kristall.desktop $(sharedir)/applications/Kristall.desktop
+	$(INSTALL_DATA) kristall-mime-info.xml $(sharedir)/mime/packages/kristall.xml
 	$(INSTALL_PROGRAM) kristall $(bindir)/kristall
 
 uninstall:

--- a/kristall-mime-info.xml
+++ b/kristall-mime-info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/gemini">
+    <comment>Gemini document</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.gemini"/>
+    <glob pattern="*.gmi"/>
+  </mime-type>
+  <mime-type type="text/x-kristall-theme">
+    <comment>Kristall theme file</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.kthm"/>
+  </mime-type>
+</mime-info>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -274,6 +274,13 @@ int main(int argc, char *argv[])
     if(urls.size() > 0) {
         for(auto url_str : urls) {
             QUrl url { url_str };
+            if (url.isRelative()) {
+                if (QFile::exists(url_str)) {
+                    url = QUrl::fromLocalFile(QFileInfo(url_str).absoluteFilePath());
+                } else {
+                    url = QUrl("gemini://" + url_str);
+                }
+            }
             if(url.isValid()) {
                 w.addNewTab(false, url);
             } else {


### PR DESCRIPTION
As I said in commit logs, this is to run Kristall by double-clicking a file from a file manager and to format it properly.

If you don't like the idea that `QUrl::fromUserInput()` guesses mostly `http://`, then I can change it to something like this instead:

```cc
QUrl url { url_str };
if (url.isRelative()) {
    if (QFile::exists(url_str)) {
        // url = QUrl::fromLocalFile(url_str) also would work here,
        // but the absolute path just looks better for me :^)
        url = QUrl::fromLocalFile(QFileInfo(url_str).absoluteFilePath());
    } else {
        url = QUrl("gemini://" + url_str);
    }
}
```