### PR TITLE
Instant theme change

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ This document contains TODO items for planned Kristall releases as well as some 
   - [ ] Add maximum text width option
   - [ ] Remember scroll position for navigating back
   - [x] Ctrl-Leftclick for "open in new tab"
-  - [ ] Selecting theme in settings dialog is now instant-change
+  - [x] Selecting theme in settings dialog is now instant-change
 - [x] Replace Qt markdown with standalone markdown renderer
   - [x] Enable basic markdown theming
   - [ ] Extent theming to support H4…H6, emph/bold text
@@ -37,12 +37,12 @@ This document contains TODO items for planned Kristall releases as well as some 
   - [ ] Allow users to gather a list of "visited pages"
   - [ ] Make default protocol configurable
 - [x] Ctrl-F search in documents
-- [ ] Add "view source" option to show original document
+- [x] Add "view source" option to show original document
 - [ ] Implement graphic fingerprint display instead of hex-based one
 - [x] `<krixano>` xq, I have a feature request for Kristall - the ability to middle click a tab to close it.
 - [x] `<krixano>` Also, middle clicking links to open them in new tab
 - [ ] Support "offline files"
-  - [ ] Allow manually caching a file to be visited when no internet connection is 
+  - [ ] Allow manually caching a file to be visited when no internet connection is
   - [ ] Add an "offline mode" that only allowes cached files
   - [ ] New url scheme for cached sites: kristall+cache://
   - [ ] Add window that allows you to manage your offline files
@@ -52,7 +52,7 @@ This document contains TODO items for planned Kristall releases as well as some 
   - [ ] Add per-site scheming
 - [ ] Setup sane default fonts
   - [ ] `Segoe UI`, `Consolas` for Windows
-  - [ ] 
+  - [ ]
 - [ ] Add support for "Downloads" folder/list
   - [ ] Download unknown mime types to `Downloads`
   - [ ] Redirect large files to `Dowloads`
@@ -71,7 +71,7 @@ This document contains TODO items for planned Kristall releases as well as some 
 - [ ] Explicitly don't support data:// urls
 
 ## Bugs
-  
+
 > <styan> xq: When using torsocks(1) on kristall QNetworkInterface complains loudly about not being permitted to create an IPv6 socket..
 
 MAC needs different default font:

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1192,9 +1192,17 @@ void BrowserTab::on_text_browser_customContextMenuRequested(const QPoint &pos)
     menu.addSeparator();
 
     QAction * copy = menu.addAction("Copy to clipboard");
-    copy->setShortcut(QKeySequence("Ctrl-C"));
+    copy->setShortcut(QKeySequence("Ctrl+C"));
     connect(copy, &QAction::triggered, [this]() {
         this->ui->text_browser->copy();
+    });
+
+    menu.addSeparator();
+
+    QAction * viewsrc = menu.addAction("View document source");
+    viewsrc->setShortcut(QKeySequence("Ctrl+U"));
+    connect(viewsrc, &QAction::triggered, [this]() {
+        mainWindow->viewPageSource();
     });
 
     menu.exec(ui->text_browser->mapToGlobal(pos));

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -73,6 +73,10 @@ public:
 
     void openSourceView();
 
+    void renderPage(const QByteArray & data, const MimeType & mime);
+
+    void rerenderPage();
+
 signals:
     void titleChanged(QString const & title);
     void locationChanged(QUrl const & url);
@@ -183,6 +187,8 @@ public:
     QTimer network_timeout_timer;
 
     QTextCursor current_search_position;
+
+    bool needs_rerender;
 };
 
 #endif // BROWSERTAB_HPP

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -143,6 +143,14 @@ void MainWindow::setUrlPreview(const QUrl &url)
     }
 }
 
+void MainWindow::viewPageSource()
+{
+    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    if(tab != nullptr) {
+        tab->openSourceView();
+    }
+}
+
 void MainWindow::on_browser_tabs_currentChanged(int index)
 {
     if(index >= 0) {
@@ -477,8 +485,5 @@ void MainWindow::on_actionManage_Certificates_triggered()
 
 void MainWindow::on_actionShow_document_source_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
-    if(tab != nullptr) {
-        tab->openSourceView();
-    }
+    this->viewPageSource();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -163,6 +163,11 @@ void MainWindow::on_browser_tabs_currentChanged(int index)
             this->ui->history_view->setModel(&tab->history);
 
             this->setFileStatus(tab->current_stats);
+
+            if (tab->needs_rerender)
+            {
+                tab->rerenderPage();
+            }
         } else {
             this->ui->outline_view->setModel(nullptr);
             this->ui->history_view->setModel(nullptr);
@@ -252,6 +257,17 @@ void MainWindow::on_actionSettings_triggered()
     kristall::saveSettings();
 
     kristall::setTheme(kristall::options.theme);
+
+    // Flag open tabs for re-render so theme
+    // changes are instantly applied.
+    for (int i = 0; i < this->ui->browser_tabs->count(); ++i)
+    {
+        qobject_cast<BrowserTab*>(this->ui->browser_tabs->widget(i))
+            ->needs_rerender = true;
+    }
+    // Re-render the currently-open tab if we have one.
+    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    if (tab) tab->rerenderPage();
 }
 
 void MainWindow::on_actionNew_Tab_triggered()

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -32,6 +32,8 @@ public:
 
     void setUrlPreview(QUrl const & url);
 
+    void viewPageSource();
+
 private slots:
     void on_browser_tabs_currentChanged(int index);
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -392,7 +392,7 @@
   </action>
   <action name="actionShow_document_source">
    <property name="text">
-    <string>Show document source</string>
+    <string>View document source</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
The instant theme changing works simply by "flagging" the open tabs for a re-render after the user OKs the settings dialog. This flag is removed when the tab becomes the current tab - it is then re-rendered. 

The current tab (if there is one) is immediately re-rendered and is obviously not flagged afterwards.

I've also added "view page source" to the right-click menu on pages. I guess it seems intuitive to have and was on the roadmap (I assumed it was referring to it being in the right-click menu). I thought I'd might as well include it in this PR since it's such a small addition.