### PR TITLE
Add font color rule for theme previews 

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -539,7 +539,8 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
             preview_style,
             this->outline);
 
-        this->ui->text_browser->setStyleSheet(QString("QTextBrowser { background-color: %1; }").arg(preview_style.background_color.name()));
+        this->ui->text_browser->setStyleSheet(QString("QTextBrowser { background-color: %1; color: %2; }")
+            .arg(preview_style.background_color.name(), preview_style.standard_color.name()));
     }
     else if (not plaintext_only and mime.is("text","markdown"))
     {

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -252,15 +252,16 @@ void SettingsDialog::reloadStylePreview()
     QUrl url { QUrl(QString("about://%1/foobar").arg(host)) };
 
     DocumentOutlineModel outline;
+    auto doc_style = current_style.derive(url);
     auto doc = GeminiRenderer::render(
         document,
         url,
-        current_style.derive(url),
+        doc_style,
         outline
     );
 
-    ui->style_preview->setStyleSheet(QString("QTextBrowser { background-color: %1; }")
-                                     .arg(doc->background_color.name()));
+    ui->style_preview->setStyleSheet(QString("QTextBrowser { background-color: %1; color: %2; }")
+                                     .arg(doc_style.background_color.name(), doc_style.standard_color.name()));
     ui->style_preview->setDocument(doc.get());
     preview_document = std::move(doc);
 }

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -35,7 +35,6 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
     std::unique_ptr<GeminiDocument> result = std::make_unique<GeminiDocument>();
     result->setDocumentMargin(themed_style.margin);
-    result->background_color = themed_style.background_color;
     result->setIndentWidth(20);
 
     bool emit_fancy_text = kristall::options.enable_text_decoration;
@@ -295,8 +294,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
     return result;
 }
 
-GeminiDocument::GeminiDocument(QObject *parent) : QTextDocument(parent),
-                                                  background_color(0x00, 0x00, 0x00)
+GeminiDocument::GeminiDocument(QObject *parent) : QTextDocument(parent)
 {
 }
 

--- a/src/renderers/geminirenderer.hpp
+++ b/src/renderers/geminirenderer.hpp
@@ -17,8 +17,6 @@ class GeminiDocument :
 public:
     explicit GeminiDocument(QObject * parent = nullptr);
     ~GeminiDocument() override;
-
-    QColor background_color;
 };
 
 struct GeminiRenderer


### PR DESCRIPTION
Closes #46, although the real fix for sites was already in #58 – here it is for the rest of the places.