### PR TITLE
Add shortcuts for quitting Kristall and toggling docks

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -43,12 +43,10 @@ MainWindow::MainWindow(QApplication * app, QWidget *parent) :
 
     for(QDockWidget * dock : findChildren<QDockWidget *>())
     {
-        QAction * act = this->ui->menuView ->addAction(dock->windowTitle());
-        act->setCheckable(true);
-        act->setChecked(dock->isVisible());
-        act->setData(QVariant::fromValue(dock));
+        QAction * act = dock->toggleViewAction();
+        act->setShortcut(dock->property("_shortcut").toString());
         // act->setIcon(dock->windowIcon());
-        connect(act, QOverload<bool>::of(&QAction::triggered), dock, &QDockWidget::setVisible);
+        this->ui->menuView->addAction(act);
     }
 
     connect(this->ui->menuNavigation, &QMenu::aboutToShow, [this]() {

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -64,6 +64,9 @@
    <property name="windowTitle">
     <string>Document Outline</string>
    </property>
+   <property name="_shortcut" stdset="0">
+    <string>Ctrl+M</string>
+   </property>
    <attribute name="dockWidgetArea">
     <number>1</number>
    </attribute>
@@ -101,6 +104,9 @@
    </property>
    <property name="windowTitle">
     <string>Bookmarks</string>
+   </property>
+   <property name="_shortcut" stdset="0">
+    <string>Ctrl+B</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -142,6 +148,9 @@
    </property>
    <property name="windowTitle">
     <string>History</string>
+   </property>
+   <property name="_shortcut" stdset="0">
+    <string>Ctrl+H</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -357,7 +366,7 @@
     <string>Go to home</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+H</string>
+    <string>Alt+Home</string>
    </property>
   </action>
   <action name="actionHelp">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -249,6 +249,9 @@
    <property name="text">
     <string>Quit</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
   </action>
   <action name="actionNew_Tab">
    <property name="text">


### PR DESCRIPTION
Had to use custom properties and rebind the Go home shortcut.

Picked Ctrl+M for opening the Document Outline dock, but I'm not really sure about it.