### PR TITLE
New features: page titles, and minor URL bar changes

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -532,6 +532,8 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
                 {
                     QString title = b[0];
                     this->page_title = title;
+
+                    // TODO: Escape HTML sequences in title (such as &mdash;)
                 }
             }
         }

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -77,6 +77,8 @@ public:
 
     void rerenderPage();
 
+    void updatePageTitle();
+
 signals:
     void titleChanged(QString const & title);
     void locationChanged(QUrl const & url);
@@ -189,6 +191,8 @@ public:
     QTextCursor current_search_position;
 
     bool needs_rerender;
+
+    QString page_title;
 };
 
 #endif // BROWSERTAB_HPP

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -149,6 +149,17 @@ void MainWindow::viewPageSource()
     }
 }
 
+void MainWindow::updateWindowTitle()
+{
+    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    if (tab == nullptr || tab->page_title.isEmpty())
+    {
+        this->setWindowTitle("Kristall");
+        return;
+    }
+    this->setWindowTitle(QString("%0 - %1").arg(tab->page_title, "Kristall"));
+}
+
 void MainWindow::on_browser_tabs_currentChanged(int index)
 {
     if(index >= 0) {
@@ -176,6 +187,7 @@ void MainWindow::on_browser_tabs_currentChanged(int index)
         this->ui->history_view->setModel(nullptr);
         this->setFileStatus(DocumentStats { });
     }
+    updateWindowTitle();
 }
 
 //void MainWindow::on_favourites_view_doubleClicked(const QModelIndex &index)
@@ -205,6 +217,11 @@ void MainWindow::on_tab_titleChanged(const QString &title)
        int index = this->ui->browser_tabs->indexOf(tab);
        assert(index >= 0);
        this->ui->browser_tabs->setTabText(index, title);
+
+       if (tab == this->ui->browser_tabs->currentWidget())
+       {
+            updateWindowTitle();
+       }
    }
 }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -34,6 +34,8 @@ public:
 
     void viewPageSource();
 
+    void updateWindowTitle();
+
 private slots:
     void on_browser_tabs_currentChanged(int index);
 

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -29,7 +29,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
         const QByteArray &input,
         QUrl const &root_url,
         DocumentStyle const & themed_style,
-        DocumentOutlineModel &outline)
+        DocumentOutlineModel &outline,
+        QString* const page_title)
 {
     TextStyleInstance text_style { themed_style };
 
@@ -154,6 +155,12 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
                 cursor.insertText(heading + "\n", fmt);
                 outline.appendH1(heading, id);
+
+                // Use first heading as the page's title.
+                if (page_title != nullptr && page_title->isEmpty())
+                {
+                    *page_title = heading;
+                }
             }
             else if (line.startsWith("=>"))
             {

--- a/src/renderers/geminirenderer.hpp
+++ b/src/renderers/geminirenderer.hpp
@@ -32,7 +32,8 @@ struct GeminiRenderer
         QByteArray const & input,
         QUrl const & root_url,
         DocumentStyle const & style,
-        DocumentOutlineModel & outline
+        DocumentOutlineModel & outline,
+        QString* const page_title = nullptr
     );
 };
 

--- a/src/widgets/searchbar.cpp
+++ b/src/widgets/searchbar.cpp
@@ -30,3 +30,25 @@ void SearchBar::keyReleaseEvent(QKeyEvent *event)
         QLineEdit::keyReleaseEvent(event);
     }
 }
+
+void SearchBar::focusInEvent(QFocusEvent *event)
+{
+    QLineEdit::focusInEvent(event);
+
+    // Allows only one "select all" on mouse release
+    // until next focus event.
+    this->selectall_flag = (event->reason() == Qt::MouseFocusReason);
+}
+
+void SearchBar::mouseReleaseEvent(QMouseEvent *event)
+{
+    QLineEdit::mouseReleaseEvent(event);
+
+    // Select all text if the bar was just focused and
+    // user did not select anything.
+    if (this->selectall_flag && QLineEdit::selectionLength() < 1)
+    {
+        QLineEdit::selectAll();
+    }
+    this->selectall_flag = false;
+}

--- a/src/widgets/searchbar.hpp
+++ b/src/widgets/searchbar.hpp
@@ -14,6 +14,10 @@ signals:
 public:
     void keyPressEvent(QKeyEvent *event) override;
     void keyReleaseEvent(QKeyEvent *event) override;
+    void focusInEvent(QFocusEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+private:
+    bool selectall_flag;
 };
 
 #endif // SEARCHBAR_HPP


### PR DESCRIPTION
Page titles are now supported on Gemini and HTML pages, and they are also shown in the window title.

Titles in Gemini documents are extracted in the GeminiRenderer's render function. If the line is a markdown header `#`, the string is copied into a string that is (optionally) passed to the function. This prevents having to re-read the entire document from start to finish just for the title.

The HTML title is extracted from the HTML document's `<title>` tag inside a `<head>` tag. I figured that only searching in the head would be the best option, as [according to this](https://www.w3.org/TR/html4/struct/global.html#edef-TITLE), valid title tags should only appear there. Thus I felt that it'd be less efficient to search past the `<head>` tags. The algorithm I've used to get the title should be fairly solid and is capable of ignoring malformed title tags.

Finally I added a subtle feature - when clicking the URL bar, all of the text is selected. I've modelled it after the behaviour typical of popular web browsers - i.e the user is still able to select text intuitively without the feature getting in the way.