### PR TITLE
Fix for #80 and strip inline styling in HTML

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -518,7 +518,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
         // Strip inline styles from page, so they don't
         // conflict with user styles.
         QString page_html = QString::fromUtf8(data);
-        page_html.replace(QRegularExpression("<style>([^<]*)</style>"), "");
+        page_html.replace(QRegularExpression("<style.*?>[\\S\\s]*?</style.*?>", QRegularExpression::CaseInsensitiveOption), "");
         document->setHtml(page_html);
 
         // Find page title in HTML

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1139,7 +1139,7 @@ bool BrowserTab::startRequest(const QUrl &url, ProtocolHandler::RequestOptions o
             this,
             "Kristall",
             tr("Your client certificate has a host filter enabled and this site does not match the host filter.\r\nNew URL: %1\r\nHost Filter: %2\r\nDo you want to keep the certificate enabled?")
-                .arg(url.toString(QUrl::FullyEncoded))
+                .arg(url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment))
                 .arg(this->current_identity.host_filter),
             QMessageBox::Yes | QMessageBox::No,
             QMessageBox::No
@@ -1181,7 +1181,7 @@ bool BrowserTab::startRequest(const QUrl &url, ProtocolHandler::RequestOptions o
 
     this->network_timeout_timer.start(kristall::options.network_timeout);
 
-    return this->current_handler->startRequest(url, options);
+    return this->current_handler->startRequest(url.adjusted(QUrl::RemoveFragment), options);
 }
 
 bool BrowserTab::enableClientCertificate(const CryptoIdentity &ident)

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -514,7 +514,11 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
         document->setDefaultFont(doc_style.standard_font);
         document->setDefaultStyleSheet(doc_style.toStyleSheet());
         document->setDocumentMargin(doc_style.margin);
+
+        // Strip inline styles from page, so they don't
+        // conflict with user styles.
         QString page_html = QString::fromUtf8(data);
+        page_html.replace(QRegularExpression("<style>([^<]*)</style>"), "");
         document->setHtml(page_html);
 
         // Find page title in HTML


### PR DESCRIPTION
Fixes #80 even though Kristall doesn't actually handle URL fragments currently

Also strips any inline styling from HTML pages, as it can cause conflicts with the user's stylesheet. 
(e.g when visiting https://lukesmith.xyz before this patch, the page background would change colour to yellow, which may make the page unreadable in client's that are using a light font colour)