### PR TITLE
Add optional home button to toolbar

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1038,6 +1038,8 @@ void BrowserTab::updateUI()
     this->ui->back_button->setEnabled(history.oneBackward(current_history_index).isValid());
     this->ui->forward_button->setEnabled(history.oneForward(current_history_index).isValid());
 
+    this->ui->home_button->setVisible(kristall::options.enable_home_btn);
+
     bool in_progress = (this->current_handler != nullptr) and this->current_handler->isInProgress();
 
     this->ui->refresh_button->setVisible(not in_progress);

--- a/src/browsertab.ui
+++ b/src/browsertab.ui
@@ -96,6 +96,22 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="home_button">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Kristall Home Page</string>
+       </property>
+       <property name="text">
+        <string>Home</string>
+       </property>
+       <property name="icon">
+        <iconset theme="go-home"/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="SearchBar" name="url_bar">
        <property name="placeholderText">
         <string>gemini://</string>

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -230,6 +230,8 @@ void SettingsDialog::setOptions(const GenericSettings &options)
     }
 
     this->ui->network_timeout->setValue(this->current_options.network_timeout);
+
+    this->ui->enable_home_btn->setChecked(this->current_options.enable_home_btn);
 }
 
 GenericSettings SettingsDialog::options() const
@@ -621,4 +623,9 @@ void SettingsDialog::on_max_redirects_valueChanged(int max_redirections)
 void SettingsDialog::on_network_timeout_valueChanged(int timeout)
 {
     this->current_options.network_timeout = timeout;
+}
+
+void SettingsDialog::on_enable_home_btn_clicked(bool checked)
+{
+    this->current_options.enable_home_btn = checked;
 }

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -120,6 +120,8 @@ private slots:
 
     void on_network_timeout_valueChanged(int arg1);
 
+    void on_enable_home_btn_clicked(bool arg1);
+
 private:
     void reloadStylePreview();
 

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -285,6 +285,20 @@
          </property>
         </widget>
        </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="label_29">
+         <property name="text">
+          <string>Additional toolbar buttons</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QCheckBox" name="enable_home_btn">
+         <property name="text">
+          <string>Home</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="style_tab">
@@ -910,6 +924,7 @@
   <tabstop>max_redirects</tabstop>
   <tabstop>redirection_mode</tabstop>
   <tabstop>network_timeout</tabstop>
+  <tabstop>enable_home_btn</tabstop>
   <tabstop>bg_change_color</tabstop>
   <tabstop>style_preview</tabstop>
   <tabstop>std_change_font</tabstop>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -45,6 +45,9 @@ struct GenericSettings
     // 5 seconds network timeout
     int network_timeout = 5000;
 
+    // Additional toolbar items
+    bool enable_home_btn = false;
+
     void load(QSettings & settings);
     void save(QSettings & settings) const;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,6 +344,8 @@ void GenericSettings::load(QSettings &settings)
 
     max_redirections = settings.value("max_redirections", 5).toInt();
     redirection_policy = RedirectionWarning(settings.value("redirection_policy ", WarnOnHostChange).toInt());
+
+    enable_home_btn = settings.value("enable_home_btn", false).toBool();
 }
 
 void GenericSettings::save(QSettings &settings) const
@@ -364,6 +366,7 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("max_redirections", max_redirections);
     settings.setValue("redirection_policy", int(redirection_policy));
     settings.setValue("network_timeout", network_timeout);
+    settings.setValue("enable_home_btn", enable_home_btn);
 }
 
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -278,6 +278,9 @@
    <property name="text">
     <string>Settings</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+,</string>
+   </property>
   </action>
   <action name="actionBackward">
    <property name="icon">


### PR DESCRIPTION
The implementation is very simple and can be altered if we end up adding more optional toolbar items
Also adds a setting which stores the user's preference of this.

Also, Ctrl+, is now bound to open the setting dialog - a shortcut you find in many programs