### PR TITLE
New features - file:// now supports directory listings & text/gemini, +more

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -276,6 +276,8 @@ void BrowserTab::on_url_bar_returnPressed()
         url = QUrl{"gemini://" + this->ui->url_bar->text()};
     }
 
+    this->ui->url_bar->clearFocus();
+
     this->navigateTo(url, PushImmediate);
 }
 

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -261,13 +261,9 @@ void BrowserTab::on_url_bar_returnPressed()
     QString urltext = this->ui->url_bar->text().trimmed();
 
     // Expand '~' to user's home directory.
-    static const QString F_PROTO = "file://";
-    static const int F_PROTO_LEN = F_PROTO.length();
-    if (urltext.startsWith(F_PROTO) &&
-        QStringRef(&urltext, F_PROTO_LEN, 2) == "~/")
-    {
-        urltext = F_PROTO + QDir::homePath() + urltext.remove(0, F_PROTO_LEN + 1);
-    }
+    static const QString PREFIX_HOME = "file://~";
+    if (urltext.startsWith(PREFIX_HOME))
+        urltext = "file://" + QDir::homePath() + urltext.remove(0, PREFIX_HOME.length());
 
     QUrl url { urltext };
 

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -38,6 +38,7 @@
 #include <QDesktopServices>
 #include <QShortcut>
 #include <QKeySequence>
+#include <QDir>
 
 #include <QPlainTextEdit>
 #include <QVBoxLayout>
@@ -257,7 +258,18 @@ void BrowserTab::openSourceView()
 
 void BrowserTab::on_url_bar_returnPressed()
 {
-    QUrl url { this->ui->url_bar->text().trimmed() };
+    QString urltext = this->ui->url_bar->text().trimmed();
+
+    // Expand '~' to user's home directory.
+    static const QString F_PROTO = "file://";
+    static const int F_PROTO_LEN = F_PROTO.length();
+    if (urltext.startsWith(F_PROTO) &&
+        QStringRef(&urltext, F_PROTO_LEN, 2) == "~/")
+    {
+        urltext = F_PROTO + QDir::homePath() + urltext.remove(0, F_PROTO_LEN + 1);
+    }
+
+    QUrl url { urltext };
 
     if (url.scheme().isEmpty())
     {

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1012,6 +1012,11 @@ void BrowserTab::on_stop_button_clicked()
     this->updateUI();
 }
 
+void BrowserTab::on_home_button_clicked()
+{
+    this->navigateTo(QUrl(kristall::options.start_page), BrowserTab::PushImmediate);
+}
+
 void BrowserTab::on_requestProgress(qint64 transferred)
 {
     this->current_stats.file_size = transferred;

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -103,6 +103,8 @@ private slots:
 
     void on_stop_button_clicked();
 
+    void on_home_button_clicked();
+
     void on_text_browser_customContextMenuRequested(const QPoint &pos);
 
     void on_enable_client_cert_button_clicked(bool checked);

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -218,6 +218,12 @@ void SettingsDialog::setOptions(const GenericSettings &options)
         this->ui->scheme_error->setChecked(true);
     }
 
+    if(this->current_options.show_hidden_files_in_dirs) {
+        this->ui->show_hidden_files->setChecked(true);
+    } else {
+        this->ui->hide_hidden_files->setChecked(true);
+    }
+
     this->ui->max_redirects->setValue(this->current_options.max_redirections);
 
     this->ui->redirection_mode->setCurrentIndex(0);
@@ -608,6 +614,16 @@ void SettingsDialog::on_scheme_os_default_clicked()
 void SettingsDialog::on_scheme_error_clicked()
 {
     this->current_options.use_os_scheme_handler = false;
+}
+
+void SettingsDialog::on_show_hidden_files_clicked()
+{
+    this->current_options.show_hidden_files_in_dirs = true;
+}
+
+void SettingsDialog::on_hide_hidden_files_clicked()
+{
+    this->current_options.show_hidden_files_in_dirs = false;
 }
 
 void SettingsDialog::on_redirection_mode_currentIndexChanged(int index)

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -114,6 +114,10 @@ private slots:
 
     void on_scheme_error_clicked();
 
+    void on_show_hidden_files_clicked();
+
+    void on_hide_hidden_files_clicked();
+
     void on_redirection_mode_currentIndexChanged(int index);
 
     void on_max_redirects_valueChanged(int arg1);

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -242,37 +242,68 @@
         </layout>
        </item>
        <item row="7" column="0">
+        <widget class="QLabel" name="label_23">
+         <property name="text">
+          <string>Hidden files in file:// directories</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <widget class="QRadioButton" name="show_hidden_files">
+           <property name="text">
+            <string>Show</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">hiddenFilesBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="hide_hidden_files">
+           <property name="text">
+            <string>Hide</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">hiddenFilesBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="8" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -285,14 +316,14 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QCheckBox" name="enable_home_btn">
          <property name="text">
           <string>Home</string>
@@ -921,6 +952,8 @@
   <tabstop>gophermap_text</tabstop>
   <tabstop>scheme_os_default</tabstop>
   <tabstop>scheme_error</tabstop>
+  <tabstop>show_hidden_files</tabstop>
+  <tabstop>hide_hidden_files</tabstop>
   <tabstop>max_redirects</tabstop>
   <tabstop>redirection_mode</tabstop>
   <tabstop>network_timeout</tabstop>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -38,6 +38,7 @@ struct GenericSettings
     TextDisplay text_display = FormattedText;
     bool enable_text_decoration = false;
     bool use_os_scheme_handler = false;
+    bool show_hidden_files_in_dirs = false;
     TextDisplay gophermap_display = FormattedText;
     int max_redirections = 5;
     RedirectionWarning redirection_policy = WarnOnHostChange;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,6 +342,8 @@ void GenericSettings::load(QSettings &settings)
 
     use_os_scheme_handler = settings.value("use_os_scheme_handler", false).toBool();
 
+    show_hidden_files_in_dirs = settings.value("show_hidden_files_in_dirs", false).toBool();
+
     max_redirections = settings.value("max_redirections", 5).toInt();
     redirection_policy = RedirectionWarning(settings.value("redirection_policy ", WarnOnHostChange).toInt());
 
@@ -363,6 +365,7 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("theme", theme_name);
     settings.setValue("gophermap_display", (gophermap_display == FormattedText) ? "rendered" : "text");
     settings.setValue("use_os_scheme_handler", use_os_scheme_handler);
+    settings.setValue("show_hidden_files_in_dirs", show_hidden_files_in_dirs);
     settings.setValue("max_redirections", max_redirections);
     settings.setValue("redirection_policy", int(redirection_policy));
     settings.setValue("network_timeout", network_timeout);

--- a/src/protocols/filehandler.cpp
+++ b/src/protocols/filehandler.cpp
@@ -1,5 +1,7 @@
 #include "filehandler.hpp"
 
+#include "../kristall.hpp"
+
 #include <QMimeDatabase>
 #include <QUrl>
 #include <QFile>
@@ -49,14 +51,17 @@ bool FileHandler::startRequest(const QUrl &url, RequestOptions options)
         QString page;
         page += QString("# Index of %1\n").arg(url.path());
 
+        auto filters = QDir::Dirs | QDir::Files | QDir::NoDot;
+        if (kristall::options.show_hidden_files_in_dirs) filters |= QDir::Hidden;
+        dir.setFilter(filters);
+
         // Iterate over files in the directory, and add links to each.
         for (unsigned i = 0; i < dir.count(); ++i)
         {
-            // Skip '.' directory.
-            if (dir[i] == ".") continue;
-
             // Add link to page.
-            page += QString("=> file://%1 %2\n").arg(dir.filePath(dir[i]), dir[i]);
+            page += QString("=> file://%1 %2\n")
+                .arg(QUrl(dir.filePath(dir[i])).toString(QUrl::FullyEncoded),
+                dir[i]);
         }
 
         emit this->requestComplete(page.toUtf8(), "text/gemini");

--- a/src/protocols/filehandler.cpp
+++ b/src/protocols/filehandler.cpp
@@ -4,6 +4,7 @@
 #include <QUrl>
 #include <QFile>
 #include <QFileInfo>
+#include <QDir>
 
 FileHandler::FileHandler()
 {
@@ -40,6 +41,25 @@ bool FileHandler::startRequest(const QUrl &url, RequestOptions options)
         }
 
         emit this->requestComplete(data, mime);
+    }
+    else if (QDir dir = QDir(url.path()); dir.exists())
+    {
+        // URL points to directory - we create Gemtext
+        // page which lists contents of directory.
+        QString page;
+        page += QString("# Index of %1\n").arg(url.path());
+
+        // Iterate over files in the directory, and add links to each.
+        for (unsigned i = 0; i < dir.count(); ++i)
+        {
+            // Skip '.' directory.
+            if (dir[i] == ".") continue;
+
+            // Add link to page.
+            page += QString("=> file://%1 %2\n").arg(dir.filePath(dir[i]), dir[i]);
+        }
+
+        emit this->requestComplete(page.toUtf8(), "text/gemini");
     }
     else
     {

--- a/src/protocols/filehandler.cpp
+++ b/src/protocols/filehandler.cpp
@@ -5,7 +5,6 @@
 #include <QMimeDatabase>
 #include <QUrl>
 #include <QFile>
-#include <QFileInfo>
 #include <QDir>
 
 FileHandler::FileHandler()
@@ -26,22 +25,9 @@ bool FileHandler::startRequest(const QUrl &url, RequestOptions options)
 
     if (file.open(QFile::ReadOnly))
     {
+        QMimeDatabase db;
+        auto mime = db.mimeTypeForUrl(url).name();
         auto data = file.readAll();
-        QString mime;
-
-        // Find mime type of file. We detect text/gemini
-        // using the file suffix.
-        QString suffix = QFileInfo(file).completeSuffix();
-        if (suffix == "gmi")
-        {
-            mime = "text/gemini";
-        }
-        else
-        {
-            QMimeDatabase db;
-            mime = db.mimeTypeForUrl(url).name();
-        }
-
         emit this->requestComplete(data, mime);
     }
     else if (QDir dir = QDir(url.path()); dir.exists())

--- a/src/protocols/filehandler.cpp
+++ b/src/protocols/filehandler.cpp
@@ -3,6 +3,7 @@
 #include <QMimeDatabase>
 #include <QUrl>
 #include <QFile>
+#include <QFileInfo>
 
 FileHandler::FileHandler()
 {
@@ -22,9 +23,22 @@ bool FileHandler::startRequest(const QUrl &url, RequestOptions options)
 
     if (file.open(QFile::ReadOnly))
     {
-        QMimeDatabase db;
-        auto mime = db.mimeTypeForUrl(url).name();
         auto data = file.readAll();
+        QString mime;
+
+        // Find mime type of file. We detect text/gemini
+        // using the file suffix.
+        QString suffix = QFileInfo(file).completeSuffix();
+        if (suffix == "gmi")
+        {
+            mime = "text/gemini";
+        }
+        else
+        {
+            QMimeDatabase db;
+            mime = db.mimeTypeForUrl(url).name();
+        }
+
         emit this->requestComplete(data, mime);
     }
     else


### PR DESCRIPTION
* Fixes home toolbar button added in #95. I forgot to include functionality for it yesterday :laughing: 
* ~~file:// protocol now supports reading local text/gemini files (checks for .gmi extension)~~ (not needed)
* Tildes (~) in the URL bar (only under file:// scheme) are now expanded to the user's home directory. Works fine under Linux, but may need testing on Windows. (Example, `file://~` becomes `file://home/user`,`file://~/test` becomes `file:///home/user/test`, and so on)
* Directories in file:// are now displayed as listings of files (screenshot below). Hidden files are optionally enabled via a preference
* URL bar focus cleared after return key press

![gscreenshot_2020-12-30-164541](https://user-images.githubusercontent.com/42143005/103332575-9345d100-4abe-11eb-99ea-ef0bb9703fad.png)
