### PR TITLE
Bugfixes, reduce warnings, small refactor

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -900,7 +900,7 @@ void BrowserTab::on_text_browser_anchorClicked(const QUrl &url, bool open_in_new
                         QInputDialog input { this };
                         input.setInputMode(QInputDialog::TextInput);
                         input.setLabelText(tr("This style has no embedded name. Please enter a name for the preset:"));
-                        input.setTextValue(this->current_location.fileName().split(".", QString::SkipEmptyParts).first());
+                        input.setTextValue(this->current_location.fileName().split(".", Qt::SkipEmptyParts).first());
 
                         if(input.exec() != QDialog::Accepted)
                             return;

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -529,6 +529,10 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
         // conflict with user styles.
         QString page_html = QString::fromUtf8(data);
         page_html.replace(QRegularExpression("<style.*?>[\\S\\s]*?</style.*?>", QRegularExpression::CaseInsensitiveOption), "");
+
+        // Strip bgcolor attribute from body. These can screw up user styles too.
+        page_html.replace(QRegularExpression("<body.*bgcolor.*>", QRegularExpression::CaseInsensitiveOption), "<body>");
+
         document->setHtml(page_html);
 
         // Find page title in HTML

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -155,7 +155,7 @@ void BrowserTab::navigateBack(const QModelIndex &history_index)
     }
 }
 
-void BrowserTab::navOneBackback()
+void BrowserTab::navOneBackward()
 {
     navigateBack(history.oneBackward(current_history_index));
 }
@@ -1039,7 +1039,7 @@ void BrowserTab::on_requestProgress(qint64 transferred)
 
 void BrowserTab::on_back_button_clicked()
 {
-    navOneBackback();
+    navOneBackward();
 }
 
 void BrowserTab::on_forward_button_clicked()

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -55,7 +55,7 @@ public:
 
     void navigateBack(const QModelIndex &history_index);
 
-    void navOneBackback();
+    void navOneBackward();
 
     void navOneForward();
 

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -318,7 +318,7 @@ bool DocumentStyle::load(QSettings &settings)
             settings.endGroup();
         }
 
-    }
+    } break;
     default:
         return false;
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include <QTextStream>
 #include <QFileDialog>
 #include <QInputDialog>
+#include <QMouseEvent>
 
 #include "ioutil.hpp"
 #include "kristall.hpp"
@@ -158,6 +159,26 @@ void MainWindow::updateWindowTitle()
         return;
     }
     this->setWindowTitle(QString("%0 - %1").arg(tab->page_title, "Kristall"));
+}
+
+void MainWindow::mousePressEvent(QMouseEvent *event)
+{
+    QMainWindow::mousePressEvent(event);
+
+    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    if (tab == nullptr) return;
+
+    // Navigate back/forward on mouse buttons 4/5
+    if (event->buttons() == Qt::ForwardButton &&
+        tab->history.oneForward(tab->current_history_index).isValid())
+    {
+        tab->navOneForward();
+    }
+    else if (event->buttons() == Qt::BackButton &&
+        tab->history.oneBackward(tab->current_history_index).isValid())
+    {
+        tab->navOneBackward();
+    }
 }
 
 void MainWindow::on_browser_tabs_currentChanged(int index)
@@ -327,7 +348,7 @@ void MainWindow::on_actionBackward_triggered()
 {
     BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
     if(tab != nullptr) {
-        tab->navOneBackback();
+        tab->navOneBackward();
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,7 +51,7 @@ MainWindow::MainWindow(QApplication * app, QWidget *parent) :
     }
 
     connect(this->ui->menuNavigation, &QMenu::aboutToShow, [this]() {
-        BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+        BrowserTab * tab = this->curTab();
         if(tab != nullptr) {
             ui->actionAdd_to_favourites->setChecked(kristall::favourites.containsUrl(tab->current_location));
         }
@@ -128,6 +128,17 @@ BrowserTab * MainWindow::addNewTab(bool focus_new, QUrl const & url)
     return tab;
 }
 
+BrowserTab * MainWindow::curTab() const
+{
+    // Was getting irritated writing this out all the time
+    return qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+}
+
+BrowserTab * MainWindow::tabAt(int index) const
+{
+    return qobject_cast<BrowserTab*>(this->ui->browser_tabs->widget(index));
+}
+
 void MainWindow::setUrlPreview(const QUrl &url)
 {
     if(url.isValid()) {
@@ -144,7 +155,7 @@ void MainWindow::setUrlPreview(const QUrl &url)
 
 void MainWindow::viewPageSource()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->openSourceView();
     }
@@ -152,7 +163,7 @@ void MainWindow::viewPageSource()
 
 void MainWindow::updateWindowTitle()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if (tab == nullptr || tab->page_title.isEmpty())
     {
         this->setWindowTitle("Kristall");
@@ -165,7 +176,7 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 {
     QMainWindow::mousePressEvent(event);
 
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if (tab == nullptr) return;
 
     // Navigate back/forward on mouse buttons 4/5
@@ -184,7 +195,7 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 void MainWindow::on_browser_tabs_currentChanged(int index)
 {
     if(index >= 0) {
-        BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->widget(index));
+        BrowserTab * tab = this->tabAt(index);
 
         if(tab != nullptr) {
             this->ui->outline_view->setModel(&tab->outline);
@@ -220,12 +231,12 @@ void MainWindow::on_browser_tabs_currentChanged(int index)
 
 void MainWindow::on_browser_tabs_tabCloseRequested(int index)
 {
-    delete this->ui->browser_tabs->widget(index);
+    delete tabAt(index);
 }
 
 void MainWindow::on_history_view_doubleClicked(const QModelIndex &index)
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->navigateBack(index);
     }
@@ -239,7 +250,7 @@ void MainWindow::on_tab_titleChanged(const QString &title)
        assert(index >= 0);
        this->ui->browser_tabs->setTabText(index, title);
 
-       if (tab == this->ui->browser_tabs->currentWidget())
+       if (tab == this->curTab())
        {
             updateWindowTitle();
        }
@@ -258,7 +269,7 @@ void MainWindow::on_tab_locationChanged(const QUrl &url)
 
 void MainWindow::on_outline_view_clicked(const QModelIndex &index)
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
 
         auto anchor = tab->outline.getAnchor(index);
@@ -298,11 +309,10 @@ void MainWindow::on_actionSettings_triggered()
     // changes are instantly applied.
     for (int i = 0; i < this->ui->browser_tabs->count(); ++i)
     {
-        qobject_cast<BrowserTab*>(this->ui->browser_tabs->widget(i))
-            ->needs_rerender = true;
+        tabAt(i)->needs_rerender = true;
     }
     // Re-render the currently-open tab if we have one.
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if (tab) tab->rerenderPage();
 }
 
@@ -330,7 +340,7 @@ https://github.com/MasterQ32/Kristall)about"
 
 void MainWindow::on_actionClose_Tab_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         delete tab;
     }
@@ -338,7 +348,7 @@ void MainWindow::on_actionClose_Tab_triggered()
 
 void MainWindow::on_actionForward_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->navOneForward();
     }
@@ -346,7 +356,7 @@ void MainWindow::on_actionForward_triggered()
 
 void MainWindow::on_actionBackward_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->navOneBackward();
     }
@@ -354,7 +364,7 @@ void MainWindow::on_actionBackward_triggered()
 
 void MainWindow::on_actionRefresh_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->reloadPage();
     }
@@ -380,7 +390,7 @@ void MainWindow::setFileStatus(const DocumentStats &stats)
 
 void MainWindow::on_actionSave_as_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         QFileDialog dialog { this };
         dialog.setAcceptMode(QFileDialog::AcceptSave);
@@ -406,7 +416,7 @@ void MainWindow::on_actionSave_as_triggered()
 
 void MainWindow::on_actionGo_to_home_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->navigateTo(QUrl(kristall::options.start_page), BrowserTab::PushImmediate);
     }
@@ -414,7 +424,7 @@ void MainWindow::on_actionGo_to_home_triggered()
 
 void MainWindow::on_actionAdd_to_favourites_triggered()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->toggleIsFavourite();
     }
@@ -435,7 +445,7 @@ void MainWindow::on_tab_fileLoaded(DocumentStats const & stats)
 
 void MainWindow::on_focus_inputbar()
 {
-    BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+    BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->focusUrlBar();
     }
@@ -449,7 +459,7 @@ void MainWindow::on_actionHelp_triggered()
 void MainWindow::on_history_view_customContextMenuRequested(const QPoint pos)
 {
     if(auto idx = this->ui->history_view->indexAt(pos); idx.isValid()) {
-        BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+        BrowserTab * tab = this->curTab();
         if(tab != nullptr) {
             if(QUrl url = tab->history.get(idx); url.isValid()) {
                 QMenu menu;
@@ -475,7 +485,7 @@ void MainWindow::on_favourites_view_customContextMenuRequested(const QPoint pos)
         if(QUrl url = kristall::favourites.getFavourite(idx).destination; url.isValid()) {
             QMenu menu;
 
-            BrowserTab * tab = qobject_cast<BrowserTab*>(this->ui->browser_tabs->currentWidget());
+            BrowserTab * tab = this->curTab();
             if(tab != nullptr) {
                 connect(menu.addAction("Open here"), &QAction::triggered, [tab, url]() {
                     tab->navigateTo(url, BrowserTab::PushImmediate);

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -29,6 +29,8 @@ public:
 
     BrowserTab * addEmptyTab(bool focus_new, bool load_default);
     BrowserTab * addNewTab(bool focus_new, QUrl const & url);
+    BrowserTab * curTab() const;
+    BrowserTab * tabAt(int index) const;
 
     void setUrlPreview(QUrl const & url);
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -36,6 +36,8 @@ public:
 
     void updateWindowTitle();
 
+    void mousePressEvent(QMouseEvent *event) override;
+
 private slots:
     void on_browser_tabs_currentChanged(int index);
 

--- a/src/protocols/abouthandler.cpp
+++ b/src/protocols/abouthandler.cpp
@@ -34,7 +34,7 @@ bool AboutHandler::startRequest(const QUrl &url, ProtocolHandler::RequestOptions
             if(current_group != fav.first) {
 
                 document.append("\n");
-                document.append(QString("## %1\n").arg(fav.first));
+                document.append(QString("## %1\n").arg(fav.first).toUtf8());
 
                 current_group = fav.first;
             }

--- a/src/protocols/webclient.cpp
+++ b/src/protocols/webclient.cpp
@@ -47,7 +47,7 @@ bool WebClient::startRequest(const QUrl &url, RequestOptions options)
     }
 
     // request.setMaximumRedirectsAllowed(5);
-    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, false);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
     request.setSslConfiguration(ssl_config);
 
     this->manager.clearAccessCache();

--- a/src/renderers/markdownrenderer.cpp
+++ b/src/renderers/markdownrenderer.cpp
@@ -304,6 +304,7 @@ static void renderNode(RenderState &state, cmark_node & node, const QTextCharFor
         qDebug() << "CMARK_NODE_IMAGE";
         break;
     }
+    default: break;
     }
 }
 


### PR DESCRIPTION
* Fixes a few deprecation warnings and other general warnings
* Fixes a bug in DocumentStyle which caused emojis to not display properly (Fixes #39)
* New feature: mouse buttons 4 and 5 now navigate backward/forward. (Closes #51)
* Slight refactor: MainWindow now has new 'shorthand' methods, curTab, and tabAt, which replace all the `qobject_cast<BrowserTab*>(this->ui->browser_tabs->..)`
* 'Unsupported media type' page is now in gemtext by default. Plaintext version used if user set to use plaintext_only.
* Now strip 'bgcolor' attribute from `<body>` on html pages (continuation of #90). For example when visiting [this page](https://lists.orbitalfox.eu/archives/gemini/2020/date.html) background is no longer changed.