### PR TITLE
New url bar formatting

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1136,6 +1136,7 @@ void BrowserTab::updateUrlBarStyle()
     // Set all text to default colour if url bar
     // is focused, is at an internal location (like about:...),
     // or has an invalid URL.
+    static bool no_style = false;
     if (!kristall::options.fancy_urlbar ||
         this->ui->url_bar->hasFocus() ||
         !url.isValid() ||
@@ -1143,10 +1144,16 @@ void BrowserTab::updateUrlBarStyle()
         mainWindow->settings_visible)
     {
         // Disable styling
-        setLineEditTextFormat(this->ui->url_bar,
-            QList<QTextLayout::FormatRange>());
+        if (!no_style)
+        {
+            setLineEditTextFormat(this->ui->url_bar,
+                QList<QTextLayout::FormatRange>());
+            no_style = true;
+        }
         return;
     }
+
+    no_style = false;
 
     // Styling enabled: 'authority' (hostname, port, etc) of
     // the URL is highlighted (i.e default colour),
@@ -1169,7 +1176,6 @@ void BrowserTab::updateUrlBarStyle()
     // The rest of the text is in default theme foreground colour.
     QTextCharFormat f;
     f.setForeground(mainWindow->palette().color(QPalette::PlaceholderText));
-
 
     // Create format range for left-side of URL
     QTextLayout::FormatRange fr_left;

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1146,22 +1146,23 @@ void BrowserTab::updateUrlBarStyle()
         return;
     }
 
-    // Styling enabled: hostname of the URL is highlighted
-    // (i.e default colour), the rest is in grey-ish colour
+    // Styling enabled: 'authority' (hostname, port, etc) of
+    // the URL is highlighted (i.e default colour),
+    // the rest is in grey-ish colour
     //
     // Example:
     //
-    // gemini://an.example.com/index.gmi
+    // gemini://an.example.com:1965/index.gmi
     // ^-------^
-    //   grey   ^------------^
-    //             default
-    //                        ^--------^
-    //                           grey
+    //   grey   ^-----------------^
+    //               default
+    //                             ^--------^
+    //                                grey
 
     QList<QTextLayout::FormatRange> formats;
 
     // We only need to create one style, which is the
-    // non-hostname colour text (grey-ish, we use the theme's
+    // non-authority colour text (grey-ish, we use the theme's
     // placeholder text colour for this).
     // The rest of the text is in default theme foreground colour.
     QTextCharFormat f;
@@ -1179,7 +1180,8 @@ void BrowserTab::updateUrlBarStyle()
     if (url.scheme() != "file" && !url.path().isEmpty())
     {
         QTextLayout::FormatRange fr_right;
-        fr_right.start = fr_left.length + url.host().length();
+
+        fr_right.start = fr_left.length + url.authority().length();
         fr_right.length = url.path().length();
         fr_right.format = f;
         formats.append(fr_right);

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1138,7 +1138,8 @@ void BrowserTab::updateUrlBarStyle()
     // or has an invalid URL.
     if (this->ui->url_bar->hasFocus() ||
         !url.isValid() ||
-        this->is_internal_location)
+        this->is_internal_location ||
+        mainWindow->settings_visible)
     {
         // Disable styling
         setLineEditTextFormat(this->ui->url_bar,

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1136,7 +1136,8 @@ void BrowserTab::updateUrlBarStyle()
     // Set all text to default colour if url bar
     // is focused, is at an internal location (like about:...),
     // or has an invalid URL.
-    if (this->ui->url_bar->hasFocus() ||
+    if (!kristall::options.fancy_urlbar ||
+        this->ui->url_bar->hasFocus() ||
         !url.isValid() ||
         this->is_internal_location ||
         mainWindow->settings_visible)

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -79,6 +79,10 @@ public:
 
     void updatePageTitle();
 
+    void setUrlBarText(const QString & text);
+
+    void updateUrlBarStyle();
+
 signals:
     void titleChanged(QString const & title);
     void locationChanged(QUrl const & url);
@@ -88,6 +92,10 @@ private slots:
     void on_url_bar_returnPressed();
 
     void on_url_bar_escapePressed();
+
+    void on_url_bar_focused();
+
+    void on_url_bar_blurred();
 
     void on_refresh_button_clicked();
 

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -218,6 +218,12 @@ void SettingsDialog::setOptions(const GenericSettings &options)
         this->ui->hide_hidden_files->setChecked(true);
     }
 
+    if(this->current_options.fancy_urlbar) {
+        this->ui->urlbarhl_fancy->setChecked(true);
+    } else {
+        this->ui->urlbarhl_none->setChecked(true);
+    }
+
     this->ui->max_redirects->setValue(this->current_options.max_redirections);
 
     this->ui->redirection_mode->setCurrentIndex(0);
@@ -618,6 +624,16 @@ void SettingsDialog::on_show_hidden_files_clicked()
 void SettingsDialog::on_hide_hidden_files_clicked()
 {
     this->current_options.show_hidden_files_in_dirs = false;
+}
+
+void SettingsDialog::on_urlbarhl_fancy_clicked()
+{
+    this->current_options.fancy_urlbar = true;
+}
+
+void SettingsDialog::on_urlbarhl_none_clicked()
+{
+    this->current_options.fancy_urlbar = false;
 }
 
 void SettingsDialog::on_redirection_mode_currentIndexChanged(int index)

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -118,6 +118,10 @@ private slots:
 
     void on_hide_hidden_files_clicked();
 
+    void on_urlbarhl_fancy_clicked();
+
+    void on_urlbarhl_none_clicked();
+
     void on_redirection_mode_currentIndexChanged(int index);
 
     void on_max_redirects_valueChanged(int arg1);

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -303,38 +303,38 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -347,14 +347,14 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QCheckBox" name="enable_home_btn">
          <property name="text">
           <string>Home</string>

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -273,6 +273,37 @@
         </layout>
        </item>
        <item row="8" column="0">
+        <widget class="QLabel" name="label_24">
+         <property name="text">
+          <string>URL bar highlights</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <item>
+          <widget class="QRadioButton" name="urlbarhl_fancy">
+           <property name="text">
+            <string>Fancy</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">urlbarBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="urlbarhl_none">
+           <property name="text">
+            <string>None</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">urlbarBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="8" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
@@ -954,6 +985,8 @@
   <tabstop>scheme_error</tabstop>
   <tabstop>show_hidden_files</tabstop>
   <tabstop>hide_hidden_files</tabstop>
+  <tabstop>urlbarhl_fancy</tabstop>
+  <tabstop>urlbarhl_none</tabstop>
   <tabstop>max_redirects</tabstop>
   <tabstop>redirection_mode</tabstop>
   <tabstop>network_timeout</tabstop>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -39,6 +39,7 @@ struct GenericSettings
     bool enable_text_decoration = false;
     bool use_os_scheme_handler = false;
     bool show_hidden_files_in_dirs = false;
+    bool fancy_urlbar = true;
     TextDisplay gophermap_display = FormattedText;
     int max_redirections = 5;
     RedirectionWarning redirection_policy = WarnOnHostChange;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,6 +344,8 @@ void GenericSettings::load(QSettings &settings)
 
     show_hidden_files_in_dirs = settings.value("show_hidden_files_in_dirs", false).toBool();
 
+    fancy_urlbar = settings.value("fancy_urlbar", true).toBool();
+
     max_redirections = settings.value("max_redirections", 5).toInt();
     redirection_policy = RedirectionWarning(settings.value("redirection_policy ", WarnOnHostChange).toInt());
 
@@ -366,6 +368,7 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("gophermap_display", (gophermap_display == FormattedText) ? "rendered" : "text");
     settings.setValue("use_os_scheme_handler", use_os_scheme_handler);
     settings.setValue("show_hidden_files_in_dirs", show_hidden_files_in_dirs);
+    settings.setValue("fancy_urlbar", fancy_urlbar);
     settings.setValue("max_redirections", max_redirections);
     settings.setValue("redirection_policy", int(redirection_policy));
     settings.setValue("network_timeout", network_timeout);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -21,6 +21,7 @@
 MainWindow::MainWindow(QApplication * app, QWidget *parent) :
     QMainWindow(parent),
     application(app),
+    settings_visible(false),
     ui(new Ui::MainWindow),
     url_status(new ElideLabel(this)),
     file_size(new QLabel(this)),
@@ -289,10 +290,22 @@ void MainWindow::on_actionSettings_triggered()
     dialog.setGeminiSslTrust(kristall::trust::gemini);
     dialog.setHttpsSslTrust(kristall::trust::https);
 
+    // We use this to disable url bar styling
+    // while we view settings, so that theme
+    // stays applied.
+    settings_visible = true;
+    this->curTab()->updateUrlBarStyle();
+
     if(dialog.exec() != QDialog::Accepted) {
         kristall::setTheme(kristall::options.theme);
+
+        settings_visible = false;
+        this->curTab()->updateUrlBarStyle();
+
         return;
     }
+
+    settings_visible = false;
 
     kristall::trust::gemini = dialog.geminiSslTrust();
     kristall::trust::https = dialog.httpsSslTrust();
@@ -309,7 +322,7 @@ void MainWindow::on_actionSettings_triggered()
     // changes are instantly applied.
     for (int i = 0; i < this->ui->browser_tabs->count(); ++i)
     {
-        BrowserTab * tab = tabAt(i);
+        BrowserTab * tab = this->tabAt(i);
         tab->needs_rerender = true;
         tab->updateUrlBarStyle();
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -309,7 +309,9 @@ void MainWindow::on_actionSettings_triggered()
     // changes are instantly applied.
     for (int i = 0; i < this->ui->browser_tabs->count(); ++i)
     {
-        tabAt(i)->needs_rerender = true;
+        BrowserTab * tab = tabAt(i);
+        tab->needs_rerender = true;
+        tab->updateUrlBarStyle();
     }
     // Re-render the currently-open tab if we have one.
     BrowserTab * tab = this->curTab();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -291,21 +291,21 @@ void MainWindow::on_actionSettings_triggered()
     dialog.setHttpsSslTrust(kristall::trust::https);
 
     // We use this to disable url bar styling
-    // while we view settings, so that theme
-    // stays applied.
-    settings_visible = true;
-    this->curTab()->updateUrlBarStyle();
+    // while we view Settings dialog, so that the URL bar
+    // doesn't look weird after changing theme.
+    static const auto update_url_style = [this](bool vis) {
+        this->settings_visible = vis;
+        if (this->curTab()) this->curTab()->updateUrlBarStyle();
+    };
+    update_url_style(true);
 
     if(dialog.exec() != QDialog::Accepted) {
         kristall::setTheme(kristall::options.theme);
-
-        settings_visible = false;
-        this->curTab()->updateUrlBarStyle();
-
+        update_url_style(false);
         return;
     }
 
-    settings_visible = false;
+    update_url_style(false);
 
     kristall::trust::gemini = dialog.geminiSslTrust();
     kristall::trust::https = dialog.httpsSslTrust();

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -101,6 +101,8 @@ private:
 
 public:
     QApplication * application;
+
+    bool settings_visible;
 private:
     Ui::MainWindow *ui;
 

--- a/src/widgets/searchbar.cpp
+++ b/src/widgets/searchbar.cpp
@@ -38,6 +38,15 @@ void SearchBar::focusInEvent(QFocusEvent *event)
     // Allows only one "select all" on mouse release
     // until next focus event.
     this->selectall_flag = (event->reason() == Qt::MouseFocusReason);
+
+    emit this->focused();
+}
+
+void SearchBar::focusOutEvent(QFocusEvent *event)
+{
+    QLineEdit::focusOutEvent(event);
+
+    emit this->blurred();
 }
 
 void SearchBar::mouseReleaseEvent(QMouseEvent *event)

--- a/src/widgets/searchbar.hpp
+++ b/src/widgets/searchbar.hpp
@@ -11,10 +11,13 @@ public:
 
 signals:
     void escapePressed();
+    void focused();
+    void blurred();
 public:
     void keyPressEvent(QKeyEvent *event) override;
     void keyReleaseEvent(QKeyEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
 private:
     bool selectall_flag;


### PR DESCRIPTION
Some subtle formatting is now applied to the URL bar to make the hostname (and port) stand out more in the URL. This is optional and a preference has been added to allow switching to the old URL bar. It's a subtle feature but I think it makes the url bar appear a little nicer

Highlights off:
![urlbar_nostyles](https://user-images.githubusercontent.com/42143005/103404379-67524a80-4ba7-11eb-84c5-7cf74984c8b7.png)

Highlights on:
![urlbar_fancy](https://user-images.githubusercontent.com/42143005/103404388-6f11ef00-4ba7-11eb-9ef7-f867054098d3.png)

The algorithm is quite solid and I haven't come across any urls which it breaks on yet. However, I feel like some of the code might be a little messy (particularly the use of the `settings_visible` variable in the main window class). I'm open to any suggestions for cleaning it up and improvements ;)