### PR TITLE
Add 'compact' layout for UI

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -59,6 +59,8 @@ BrowserTab::BrowserTab(MainWindow *mainWindow) : QWidget(nullptr),
 {
     ui->setupUi(this);
 
+    this->setUiDensity(kristall::options.ui_density);
+
     addProtocolHandler<GeminiClient>();
     addProtocolHandler<FingerClient>();
     addProtocolHandler<GopherClient>();
@@ -1197,6 +1199,24 @@ void BrowserTab::updateUrlBarStyle()
 
     // Finally, apply the colour formatting.
     setLineEditTextFormat(this->ui->url_bar, formats);
+}
+
+void BrowserTab::setUiDensity(UIDensity density)
+{
+    switch (density)
+    {
+    case UIDensity::compact:
+    {
+        this->ui->layout_main->setContentsMargins(0, 0, 0, 0);
+        this->ui->layout_toolbar->setContentsMargins(8, 0, 8, 0);
+    } break;
+
+    case UIDensity::classic:
+    {
+        this->ui->layout_main->setContentsMargins(0, 9, 0, 9);
+        this->ui->layout_toolbar->setContentsMargins(18, 9, 18, 9);
+    } break;
+    }
 }
 
 bool BrowserTab::trySetClientCertificate(const QString &query)

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -27,6 +27,8 @@ class BrowserTab;
 
 class MainWindow;
 
+enum class UIDensity : int;
+
 struct DocumentStats
 {
     int loading_time = 0; // in ms
@@ -82,6 +84,8 @@ public:
     void setUrlBarText(const QString & text);
 
     void updateUrlBarStyle();
+
+    void setUiDensity(UIDensity density);
 
 signals:
     void titleChanged(QString const & title);

--- a/src/browsertab.ui
+++ b/src/browsertab.ui
@@ -13,9 +13,9 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="layout_main">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="layout_toolbar">
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>
      </property>

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -34,6 +34,10 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
     this->ui->ui_theme->addItem(tr("Light"), QVariant::fromValue<int>(int(Theme::light)));
     this->ui->ui_theme->addItem(tr("Dark"), QVariant::fromValue<int>(int(Theme::dark)));
 
+    this->ui->ui_density->clear();
+    this->ui->ui_density->addItem(tr("Compact"), QVariant::fromValue<int>(int(UIDensity::compact)));
+    this->ui->ui_density->addItem(tr("Classic"), QVariant::fromValue<int>(int(UIDensity::classic)));
+
     setGeminiStyle(DocumentStyle { });
 
     this->predefined_styles.clear();
@@ -182,6 +186,14 @@ void SettingsDialog::setOptions(const GenericSettings &options)
     for(int i = 0; i < this->ui->ui_theme->count(); i++) {
         if(this->ui->ui_theme->itemData(i).toInt() == int(options.theme)) {
             this->ui->ui_theme->setCurrentIndex(i);
+            break;
+        }
+    }
+
+    this->ui->ui_density->setCurrentIndex(0);
+    for(int i = 0; i < this->ui->ui_density->count(); ++i) {
+        if (this->ui->ui_density->itemData(i).toInt() == int(options.ui_density)) {
+            this->ui->ui_density->setCurrentIndex(i);
             break;
         }
     }
@@ -574,6 +586,13 @@ void SettingsDialog::on_ui_theme_currentIndexChanged(int index)
     this->current_options.theme = Theme(this->ui->ui_theme->itemData(index).toInt());
 
     kristall::setTheme(this->current_options.theme);
+}
+
+void SettingsDialog::on_ui_density_currentIndexChanged(int index)
+{
+    this->current_options.ui_density = UIDensity(this->ui->ui_density->itemData(index).toInt());
+
+    kristall::setUiDensity(this->current_options.ui_density, true);
 }
 
 void SettingsDialog::on_fancypants_on_clicked()

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -98,6 +98,8 @@ private slots:
 
     void on_ui_theme_currentIndexChanged(int index);
 
+    void on_ui_density_currentIndexChanged(int index);
+
     void on_fancypants_on_clicked();
 
     void on_fancypants_off_clicked();

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -43,27 +43,37 @@
         <widget class="QComboBox" name="ui_theme"/>
        </item>
        <item row="1" column="0">
+        <widget class="QLabel" name="label_1">
+         <property name="text">
+          <string>UI Density</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="ui_density"/>
+       </item>
+       <item row="2" column="0">
         <widget class="QLabel" name="label_14">
          <property name="text">
           <string>Start Page:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="start_page">
          <property name="placeholderText">
           <string>about://blank</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>Enabled Protocols</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QCheckBox" name="enable_gemini">
@@ -108,14 +118,14 @@
          </item>
         </layout>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_19">
          <property name="text">
           <string>Text Rendering</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QRadioButton" name="fancypants_on">
@@ -142,14 +152,14 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_18">
          <property name="text">
           <string>Enable text highlights</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QRadioButton" name="texthl_on">
@@ -176,14 +186,14 @@
          </item>
         </layout>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_20">
          <property name="text">
           <string>Gopher Map</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QRadioButton" name="gophermap_icon">
@@ -210,14 +220,14 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_22">
          <property name="text">
           <string>Unknown Scheme</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
           <widget class="QRadioButton" name="scheme_os_default">
@@ -241,14 +251,14 @@
          </item>
         </layout>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_23">
          <property name="text">
           <string>Hidden files in file:// directories</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_8">
          <item>
           <widget class="QRadioButton" name="show_hidden_files">
@@ -272,14 +282,14 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_24">
          <property name="text">
           <string>URL bar highlights</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
           <widget class="QRadioButton" name="urlbarhl_fancy">
@@ -303,38 +313,38 @@
          </item>
         </layout>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -347,14 +357,14 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QCheckBox" name="enable_home_btn">
          <property name="text">
           <string>Home</string>
@@ -969,6 +979,7 @@
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>ui_theme</tabstop>
+  <tabstop>ui_density</tabstop>
   <tabstop>start_page</tabstop>
   <tabstop>enable_gemini</tabstop>
   <tabstop>enable_gopher</tabstop>
@@ -1059,5 +1070,7 @@
   <buttongroup name="textHighlightsBtnGroup"/>
   <buttongroup name="textRenderingBtnGroup"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="hiddenFilesBtnGroup"/>
+  <buttongroup name="urlbarBtnGroup"/>
  </buttongroups>
 </ui>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -19,6 +19,12 @@ enum class Theme : int
     dark = 1,
 };
 
+enum class UIDensity : int
+{
+    compact = 0,
+    classic = 1
+};
+
 struct GenericSettings
 {
     enum TextDisplay {
@@ -35,6 +41,7 @@ struct GenericSettings
 
     QString start_page = "about:favourites";
     Theme theme = Theme::light;
+    UIDensity ui_density = UIDensity::compact;
     TextDisplay text_display = FormattedText;
     bool enable_text_decoration = false;
     bool use_os_scheme_handler = false;
@@ -103,6 +110,8 @@ namespace kristall
     void saveSettings();
 
     void setTheme(Theme theme);
+
+    void setUiDensity(UIDensity density, bool previewing);
 }
 
 #endif // KRISTALL_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@ QString toFingerprintString(QSslCertificate const & certificate)
 
 static QSettings * app_settings_ptr;
 static QApplication * app;
+static MainWindow * main_window = nullptr;
 
 #define SSTR(X) STR(X)
 #define STR(X) #X
@@ -269,6 +270,7 @@ int main(int argc, char *argv[])
     kristall::setTheme(kristall::options.theme);
 
     MainWindow w(&app);
+    main_window = &w;
 
     auto urls = cli_parser.positionalArguments();
     if(urls.size() > 0) {
@@ -335,6 +337,12 @@ void GenericSettings::load(QSettings &settings)
     else
         theme = Theme::os_default;
 
+    QString density = settings.value("ui_density", "compact").toString();
+    if(density == "compact")
+        ui_density = UIDensity::compact;
+    else if (density == "classic")
+        ui_density = UIDensity::classic;
+
     if(settings.value("gophermap_display", "rendered").toString() == "rendered")
         gophermap_display = FormattedText;
     else
@@ -363,8 +371,15 @@ void GenericSettings::save(QSettings &settings) const
     case Theme::light:      theme_name = "light"; break;
     case Theme::os_default: theme_name = "os_default"; break;
     }
-
     settings.setValue("theme", theme_name);
+
+    QString density = "compact";
+    switch(ui_density) {
+    case UIDensity::compact: density = "compact"; break;
+    case UIDensity::classic: density = "classic"; break;
+    }
+    settings.setValue("ui_density", density);
+
     settings.setValue("gophermap_display", (gophermap_display == FormattedText) ? "rendered" : "text");
     settings.setValue("use_os_scheme_handler", use_os_scheme_handler);
     settings.setValue("show_hidden_files_in_dirs", show_hidden_files_in_dirs);
@@ -436,4 +451,11 @@ void kristall::setTheme(Theme theme)
 
         QIcon::setThemeName("dark");
     }
+}
+
+void kristall::setUiDensity(UIDensity density, bool previewing)
+{
+    assert(app != nullptr);
+    assert(main_window != nullptr);
+    main_window->setUiDensity(density, previewing);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -109,6 +109,7 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
 
     if(focus_new) {
         this->ui->browser_tabs->setCurrentIndex(index);
+        tab->focusUrlBar();
     }
 
     if(load_default) {
@@ -116,8 +117,6 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
     } else {
         tab->navigateTo(QUrl("about:blank"), BrowserTab::DontPush);
     }
-
-    tab->focusUrlBar();
 
     return tab;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -173,6 +173,24 @@ void MainWindow::updateWindowTitle()
     this->setWindowTitle(QString("%0 - %1").arg(tab->page_title, "Kristall"));
 }
 
+void MainWindow::setUiDensity(UIDensity density, bool previewing)
+{
+    // If we are previewing, we only update the current tab.
+    // If not, we update all tabs as it means user accepted the settings
+    // dialog.
+
+    if (previewing)
+    {
+        if (!this->curTab()) return;
+        this->curTab()->setUiDensity(density);
+    }
+    else
+    {
+        for (int i = 0; i < this->ui->browser_tabs->count(); ++i)
+            this->tabAt(i)->setUiDensity(density);
+    }
+}
+
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
     QMainWindow::mousePressEvent(event);
@@ -301,6 +319,7 @@ void MainWindow::on_actionSettings_triggered()
 
     if(dialog.exec() != QDialog::Accepted) {
         kristall::setTheme(kristall::options.theme);
+        this->setUiDensity(kristall::options.ui_density, false);
         update_url_style(false);
         return;
     }
@@ -317,6 +336,7 @@ void MainWindow::on_actionSettings_triggered()
     kristall::saveSettings();
 
     kristall::setTheme(kristall::options.theme);
+    this->setUiDensity(kristall::options.ui_density, false);
 
     // Flag open tabs for re-render so theme
     // changes are instantly applied.

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -19,6 +19,8 @@ QT_END_NAMESPACE
 
 class BrowserTab;
 
+enum class UIDensity : int;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -37,6 +39,8 @@ public:
     void viewPageSource();
 
     void updateWindowTitle();
+
+    void setUiDensity(UIDensity density, bool previewing);
 
     void mousePressEvent(QMouseEvent *event) override;
 


### PR DESCRIPTION
There are now two options of UI density:

"Compact":
![compact](https://user-images.githubusercontent.com/42143005/103436976-c7afbd80-4c75-11eb-80fe-6d7419b7504c.png)

"Classic" (old layout):
![classic](https://user-images.githubusercontent.com/42143005/103436981-d8f8ca00-4c75-11eb-85d7-92b3bf9ab203.png)

I've set 'compact' to be the default. I can change the default setting if you like - I just felt that the 'compact' layout saves some space on the screen and would probably be preferable for new users