### PR TITLE
Fixes for building on ubuntu 20.04 / qt5.12

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -47,7 +47,7 @@
 
 #include <QGraphicsPixmapItem>
 #include <QGraphicsTextItem>
-
+#include <QRegularExpression>
 #include <iconv.h>
 
 BrowserTab::BrowserTab(MainWindow *mainWindow) : QWidget(nullptr),
@@ -551,15 +551,15 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
 
         // Find page title in HTML
         // Split so we only look in the <head>
-        QStringList head = page_html.split("</head>", Qt::KeepEmptyParts, Qt::CaseInsensitive);
+        QStringList head = page_html.split("</head>", QString::KeepEmptyParts, Qt::CaseInsensitive);
         if (head[0] != page_html)
         {
             // Split at first title tag.
-            QStringList a = head[0].split("<title>", Qt::KeepEmptyParts, Qt::CaseInsensitive);
+            QStringList a = head[0].split("<title>", QString::KeepEmptyParts, Qt::CaseInsensitive);
             if (a[0] != head[0])
             {
                 // Split at second tag.
-                QStringList b = a[1].split("</title>", Qt::KeepEmptyParts, Qt::CaseInsensitive);
+                QStringList b = a[1].split("</title>", QString::KeepEmptyParts, Qt::CaseInsensitive);
                 if (b[0] != a[1])
                 {
                     QTextDocument title;
@@ -943,7 +943,7 @@ void BrowserTab::on_text_browser_anchorClicked(const QUrl &url, bool open_in_new
                         QInputDialog input { this };
                         input.setInputMode(QInputDialog::TextInput);
                         input.setLabelText(tr("This style has no embedded name. Please enter a name for the preset:"));
-                        input.setTextValue(this->current_location.fileName().split(".", Qt::SkipEmptyParts).first());
+                        input.setTextValue(this->current_location.fileName().split(".", QString::SkipEmptyParts).first());
 
                         if(input.exec() != QDialog::Accepted)
                             return;


### PR DESCRIPTION
I couldn't build this on Ubuntu 20.04 (xubuntu) since the last release.  These changes fixed that, but I honestly don't know if this will cause other problems for other QT versions.

Errors I got:

```
$ make
mkdir -p build
cd build;  qmake ../src/kristall.pro && make 
make[1]: Entering directory '/home/gdorn/workspace/kristall/build'
g++ -c -pipe -Wno-unused-parameter -Werror=return-type -std=c++17 -O2 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DKRISTALL_VERSION="V0.3-136-g0c022e3" -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_WIDGETS_LIB -DQT_MULTIMEDIA_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I../src -I. -I../lib/cmark/src -I../lib/luis-l-gist -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtSvg -isystem /usr/include/x86_64-linux-gnu/qt5/QtMultimediaWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtMultimedia -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtNetwork -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -I. -I. -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o browsertab.o ../src/browsertab.cpp
../src/browsertab.cpp: In member function ‘void BrowserTab::renderPage(const QByteArray&, const MimeType&)’:
../src/browsertab.cpp:545:101: error: incomplete type ‘QRegularExpression’ used in nested name specifier
  545 |         page_html.replace(QRegularExpression("<style.*?>[\\S\\s]*?</style.*?>", QRegularExpression::CaseInsensitiveOption), "");
      |                                                                                                     ^~~~~~~~~~~~~~~~~~~~~
../src/browsertab.cpp:545:122: error: invalid use of incomplete type ‘class QRegularExpression’
  545 |         page_html.replace(QRegularExpression("<style.*?>[\\S\\s]*?</style.*?>", QRegularExpression::CaseInsensitiveOption), "");
      |                                                                                                                          ^
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qobject.h:47,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qwidget.h:45,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QWidget:1,
                 from ../src/browsertab.hpp:5,
                 from ../src/browsertab.cpp:1:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:83:7: note: forward declaration of ‘class QRegularExpression’
   83 | class QRegularExpression;
      |       ^~~~~~~~~~~~~~~~~~
../src/browsertab.cpp:548:87: error: incomplete type ‘QRegularExpression’ used in nested name specifier
  548 |         page_html.replace(QRegularExpression("<body.*bgcolor.*>", QRegularExpression::CaseInsensitiveOption), "<body>");
      |                                                                                       ^~~~~~~~~~~~~~~~~~~~~
../src/browsertab.cpp:548:108: error: invalid use of incomplete type ‘class QRegularExpression’
  548 |         page_html.replace(QRegularExpression("<body.*bgcolor.*>", QRegularExpression::CaseInsensitiveOption), "<body>");
      |                                                                                                            ^
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qobject.h:47,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qwidget.h:45,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QWidget:1,
                 from ../src/browsertab.hpp:5,
                 from ../src/browsertab.cpp:1:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:83:7: note: forward declaration of ‘class QRegularExpression’
   83 | class QRegularExpression;
      |       ^~~~~~~~~~~~~~~~~~
../src/browsertab.cpp:554:59: error: ‘KeepEmptyParts’ is not a member of ‘Qt’
  554 |         QStringList head = page_html.split("</head>", Qt::KeepEmptyParts, Qt::CaseInsensitive);
      |                                                           ^~~~~~~~~~~~~~
../src/browsertab.cpp:558:58: error: ‘KeepEmptyParts’ is not a member of ‘Qt’
  558 |             QStringList a = head[0].split("<title>", Qt::KeepEmptyParts, Qt::CaseInsensitive);
      |                                                          ^~~~~~~~~~~~~~
../src/browsertab.cpp:562:60: error: ‘KeepEmptyParts’ is not a member of ‘Qt’
  562 |                 QStringList b = a[1].split("</title>", Qt::KeepEmptyParts, Qt::CaseInsensitive);
      |                                                            ^~~~~~~~~~~~~~
../src/browsertab.cpp: In member function ‘void BrowserTab::on_text_browser_anchorClicked(const QUrl&, bool)’:
../src/browsertab.cpp:946:93: error: ‘SkipEmptyParts’ is not a member of ‘Qt’
  946 |                         input.setTextValue(this->current_location.fileName().split(".", Qt::SkipEmptyParts).first());
      |                                                                                             ^~~~~~~~~~~~~~
make[1]: *** [Makefile:1455: browsertab.o] Error 1
make[1]: Leaving directory '/home/gdorn/workspace/kristall/build'
make: *** [Makefile:34: build/kristall] Error 2
```

`KeepEmptyParts` and `SkipEmptyParts` appear to have moved to `QString` a few versions ago.  I'm unclear why `QRegularExpression` isn't available anymore without explicitly importing it, but that should at least be backwards compatible, I think.