### PR TITLE
Changes to Favourites widget, bugfixes, and other changes

### DIFF
--- a/Kristall.desktop
+++ b/Kristall.desktop
@@ -1,10 +1,11 @@
 [Desktop Entry]
 Name=Kristall
-GenericName=Kristall
-Comment=Graphical gemini client
-Categories=Network;
+GenericName=Gemini client
+Comment=Surf geminispace, gopherspace, and the web
+Categories=Network;WebBrowser
 Icon=net.random-projects.kristall
 Exec=kristall %u
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/gemini;x-scheme-handler/gopher;x-scheme-handler/finger;text/gemini;text/markdown;text/x-kristall-theme;
+Keywords=gemini;gopher;browser

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1115,7 +1115,7 @@ void BrowserTab::setUrlBarText(const QString & text)
 void BrowserTab::updateUrlBarStyle()
 {
     // https://stackoverflow.com/a/14424003
-    static const auto setLineEditTextFormat =
+    const auto setLineEditTextFormat =
         [](QLineEdit* l, const QList<QTextLayout::FormatRange>& f)
     {
         if (!l) return;
@@ -1138,7 +1138,6 @@ void BrowserTab::updateUrlBarStyle()
     // Set all text to default colour if url bar
     // is focused, is at an internal location (like about:...),
     // or has an invalid URL.
-    static bool no_style = false;
     if (!kristall::options.fancy_urlbar ||
         this->ui->url_bar->hasFocus() ||
         !url.isValid() ||
@@ -1146,16 +1145,16 @@ void BrowserTab::updateUrlBarStyle()
         mainWindow->settings_visible)
     {
         // Disable styling
-        if (!no_style)
+        if (!this->no_url_style)
         {
             setLineEditTextFormat(this->ui->url_bar,
                 QList<QTextLayout::FormatRange>());
-            no_style = true;
+            this->no_url_style = true;
         }
         return;
     }
 
-    no_style = false;
+    this->no_url_style = false;
 
     // Styling enabled: 'authority' (hostname, port, etc) of
     // the URL is highlighted (i.e default colour),
@@ -1173,11 +1172,10 @@ void BrowserTab::updateUrlBarStyle()
     QList<QTextLayout::FormatRange> formats;
 
     // We only need to create one style, which is the
-    // non-authority colour text (grey-ish, we use the theme's
-    // placeholder text colour for this).
+    // non-authority colour text (grey-ish, determined by theme in kristall:setTheme)
     // The rest of the text is in default theme foreground colour.
     QTextCharFormat f;
-    f.setForeground(mainWindow->palette().color(QPalette::Mid));
+    f.setForeground(kristall::options.fancy_urlbar_dim_colour);
 
     // Create format range for left-side of URL
     QTextLayout::FormatRange fr_left;

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -706,6 +706,8 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
     emit this->locationChanged(this->current_location);
 
     this->updateUI();
+
+    this->updateUrlBarStyle();
 }
 
 void BrowserTab::rerenderPage()
@@ -1141,8 +1143,7 @@ void BrowserTab::updateUrlBarStyle()
     if (!kristall::options.fancy_urlbar ||
         this->ui->url_bar->hasFocus() ||
         !url.isValid() ||
-        this->is_internal_location ||
-        mainWindow->settings_visible)
+        this->is_internal_location)
     {
         // Disable styling
         if (!this->no_url_style)

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -190,7 +190,7 @@ void BrowserTab::toggleIsFavourite(bool shouldBeFavourite)
     // we yet need to add it.
     if (shouldBeFavourite)
     {
-        kristall::favourites.addUnsorted(this->current_location);
+        kristall::favourites.addUnsorted(this->current_location, this->page_title);
     }
     else
     {
@@ -1191,7 +1191,7 @@ void BrowserTab::updateUrlBarStyle()
         QTextLayout::FormatRange fr_right;
 
         fr_right.start = fr_left.length + url.authority().length();
-        fr_right.length = url.path().length();
+        fr_right.length = url.toString(QUrl::FullyEncoded).length() - fr_right.start;
         fr_right.format = f;
         formats.append(fr_right);
     }

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -207,6 +207,8 @@ public:
     bool needs_rerender;
 
     QString page_title;
+
+    bool no_url_style = false;
 };
 
 #endif // BROWSERTAB_HPP

--- a/src/favouritecollection.hpp
+++ b/src/favouritecollection.hpp
@@ -77,6 +77,10 @@ public:
 
     bool addFavourite(QString const & group, Favourite const & fav);
 
+    void editFavouriteTitle(const QModelIndex &index, const QString &title);
+
+    void editFavouriteDest(const QModelIndex & index, const QUrl & url);
+
     Favourite getFavourite(QModelIndex const & index) const;
 
     Favourite * getMutableFavourite(QModelIndex const & index);
@@ -98,7 +102,7 @@ public:
 
     bool containsUrl(QUrl const & url) const;
 
-    bool addUnsorted(QUrl const & url);
+    bool addUnsorted(QUrl const & url, QString const & title);
 
     bool removeUrl(QUrl const & url);
 

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -47,6 +47,10 @@ struct GenericSettings
     bool use_os_scheme_handler = false;
     bool show_hidden_files_in_dirs = false;
     bool fancy_urlbar = true;
+
+    // This is set automatically
+    QColor fancy_urlbar_dim_colour;
+
     TextDisplay gophermap_display = FormattedText;
     int max_redirections = 5;
     RedirectionWarning redirection_policy = WarnOnHostChange;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -432,7 +432,14 @@ void kristall::setTheme(Theme theme)
     if(theme == Theme::os_default)
     {
         app->setStyleSheet("");
+
+        // For Linux we use standard icon set,
+        // for Windows & Mac we need to include our own icons.
+#if defined Q_OS_WIN32 || defined Q_OS_DARWIN
+        QIcon::setThemeName("light");
+#else
         QIcon::setThemeName("");
+#endif
 
         // Use "mid" colour for our URL bar dim colour:
         kristall::options.fancy_urlbar_dim_colour

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -460,6 +460,9 @@ void kristall::setTheme(Theme theme)
 
         kristall::options.fancy_urlbar_dim_colour = QColor(150, 150, 150, 255);
     }
+
+    if (main_window && main_window->curTab())
+        main_window->curTab()->updateUrlBarStyle();
 }
 
 void kristall::setUiDensity(UIDensity density, bool previewing)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -428,12 +428,17 @@ void kristall::saveSettings()
 void kristall::setTheme(Theme theme)
 {
     assert(app != nullptr);
+
     if(theme == Theme::os_default)
     {
         app->setStyleSheet("");
         QIcon::setThemeName("");
+
+        // Use "mid" colour for our URL bar dim colour:
+        kristall::options.fancy_urlbar_dim_colour
+            = app->palette().color(QPalette::Mid);
     }
-    if(theme == Theme::light)
+    else if(theme == Theme::light)
     {
         QFile file(":/light.qss");
         file.open(QFile::ReadOnly | QFile::Text);
@@ -441,6 +446,8 @@ void kristall::setTheme(Theme theme)
         app->setStyleSheet(stream.readAll());
 
         QIcon::setThemeName("light");
+
+        kristall::options.fancy_urlbar_dim_colour = QColor(128, 128, 128, 255);
     }
     else if(theme == Theme::dark)
     {
@@ -450,6 +457,8 @@ void kristall::setTheme(Theme theme)
         app->setStyleSheet(stream.readAll());
 
         QIcon::setThemeName("dark");
+
+        kristall::options.fancy_urlbar_dim_colour = QColor(150, 150, 150, 255);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -108,13 +108,16 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
 
     if(focus_new) {
         this->ui->browser_tabs->setCurrentIndex(index);
-        tab->focusUrlBar();
     }
 
     if(load_default) {
         tab->navigateTo(QUrl(kristall::options.start_page), BrowserTab::PushImmediate);
     } else {
         tab->navigateTo(QUrl("about:blank"), BrowserTab::DontPush);
+    }
+
+    if(focus_new) {
+        tab->focusUrlBar();
     }
 
     return tab;
@@ -239,12 +242,12 @@ void MainWindow::on_browser_tabs_currentChanged(int index)
     updateWindowTitle();
 }
 
-//void MainWindow::on_favourites_view_doubleClicked(const QModelIndex &index)
-//{
-//    if(auto url = kristall::favourites.getFavourite(index).destination; url.isValid()) {
-//        this->addNewTab(true, url);
-//    }
-//}
+void MainWindow::on_favourites_view_doubleClicked(const QModelIndex &index)
+{
+    if(auto url = kristall::favourites.getFavourite(index).destination; url.isValid()) {
+        this->addNewTab(true, url);
+    }
+}
 
 void MainWindow::on_browser_tabs_tabCloseRequested(int index)
 {
@@ -513,6 +516,34 @@ void MainWindow::on_favourites_view_customContextMenuRequested(const QPoint pos)
 
             connect(menu.addAction("Open in new tab"), &QAction::triggered, [this, url]() {
                 addNewTab(true, url);
+            });
+
+            menu.addSeparator();
+
+            connect(menu.addAction("Rename"), &QAction::triggered, [this, idx]() {
+                QInputDialog dialog { this };
+
+                dialog.setInputMode(QInputDialog::TextInput);
+                dialog.setLabelText(tr("New name of this favourite:"));
+                dialog.setTextValue(kristall::favourites.getFavourite(idx).getTitle());
+
+                if (dialog.exec() != QDialog::Accepted)
+                    return;
+
+                kristall::favourites.editFavouriteTitle(idx, dialog.textValue());
+            });
+
+            connect(menu.addAction("Relocate"), &QAction::triggered, [this, idx]() {
+                QInputDialog dialog { this };
+
+                dialog.setInputMode(QInputDialog::TextInput);
+                dialog.setLabelText(tr("Enter new location of this favourite:"));
+                dialog.setTextValue(kristall::favourites.getFavourite(idx).destination.toString(QUrl::FullyEncoded));
+
+                if (dialog.exec() != QDialog::Accepted)
+                    return;
+
+                kristall::favourites.editFavouriteDest(idx, QUrl(dialog.textValue()));
             });
 
             menu.addSeparator();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -112,12 +112,9 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
 
     if(load_default) {
         tab->navigateTo(QUrl(kristall::options.start_page), BrowserTab::PushImmediate);
+        tab->focusUrlBar();
     } else {
         tab->navigateTo(QUrl("about:blank"), BrowserTab::DontPush);
-    }
-
-    if(focus_new) {
-        tab->focusUrlBar();
     }
 
     return tab;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -21,7 +21,6 @@
 MainWindow::MainWindow(QApplication * app, QWidget *parent) :
     QMainWindow(parent),
     application(app),
-    settings_visible(false),
     ui(new Ui::MainWindow),
     url_status(new ElideLabel(this)),
     file_size(new QLabel(this)),
@@ -307,23 +306,11 @@ void MainWindow::on_actionSettings_triggered()
     dialog.setGeminiSslTrust(kristall::trust::gemini);
     dialog.setHttpsSslTrust(kristall::trust::https);
 
-    // We use this to disable url bar styling
-    // while we view Settings dialog, so that the URL bar
-    // doesn't look weird after changing theme.
-    static const auto update_url_style = [this](bool vis) {
-        this->settings_visible = vis;
-        if (this->curTab()) this->curTab()->updateUrlBarStyle();
-    };
-    update_url_style(true);
-
     if(dialog.exec() != QDialog::Accepted) {
         kristall::setTheme(kristall::options.theme);
         this->setUiDensity(kristall::options.ui_density, false);
-        update_url_style(false);
         return;
     }
-
-    update_url_style(false);
 
     kristall::trust::gemini = dialog.geminiSslTrust();
     kristall::trust::https = dialog.httpsSslTrust();
@@ -341,9 +328,7 @@ void MainWindow::on_actionSettings_triggered()
     // changes are instantly applied.
     for (int i = 0; i < this->ui->browser_tabs->count(); ++i)
     {
-        BrowserTab * tab = this->tabAt(i);
-        tab->needs_rerender = true;
-        tab->updateUrlBarStyle();
+        this->tabAt(i)->needs_rerender = true;
     }
     // Re-render the currently-open tab if we have one.
     BrowserTab * tab = this->curTab();

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -106,7 +106,6 @@ private:
 public:
     QApplication * application;
 
-    bool settings_visible;
 private:
     Ui::MainWindow *ui;
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -83,6 +83,8 @@ private slots:
 
     void on_favourites_view_customContextMenuRequested(const QPoint pos);
 
+    void on_favourites_view_doubleClicked(const QModelIndex &index);
+
     void on_actionChangelog_triggered();
 
     void on_actionManage_Certificates_triggered();


### PR DESCRIPTION
* slightly changed Kristall.desktop
* Bug fixes and code cleanup for fancy url bar. Now works on pages with URL queries and fragments. Fancy preference setting is now applied instantly, and no longer bugs out after changing UI theme. A custom grey colour is now used for the default Light/Dark themes. 'mid' from palette is still used for OS default theme.
* Favourites: (mostly closes #77) double clicking items in favourites_view now opens page in new tab. No return key press currently though
* Favourites: right click context menu for items now include "Rename" and "Relocate"
* Favourites: page title is now used as favourite name when adding new favourites if such title exists, if not the URL is used as the default title
* Theme: standard icons in OS default theme (#88) are no longer used on Windows and Mac builds, as these platforms do not have standard icons (e.g UI icons were missing on Windows builds). These platforms now use the "light" icon set
* Other slight tweaks

Sorry for mashing so much stuff into one PR :laughing: 