### PR TITLE
Allow to use external cmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ kristall: build/kristall
 .PHONY: build/kristall
 build/kristall: src/*
 	mkdir -p build
-	cd build; $(HOMEBREW_PATH) $(QMAKE_COMMAND) ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
-
+	cd build; $(HOMEBREW_PATH) $(QMAKE_COMMAND) CONFIG+=$(QMAKE_CONFIG) ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
 install: kristall
 	# Prepare directories
 	$(MAKEDIR) $(sharedir)/icons/hicolor/scalable/apps/

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -66,7 +66,12 @@ android: include(/home/felix/projects/android-hass/android-sdk/android_openssl/o
 # }
 
 
-include($$PWD/../lib/cmark/cmark.pri)
+external-cmark {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += libcmark
+} else {
+    include($$PWD/../lib/cmark/cmark.pri)
+}
 
 INCLUDEPATH += $$PWD/../lib/luis-l-gist/
 DEPENDPATH += $$PWD/../lib/luis-l-gist/


### PR DESCRIPTION
`make QMAKE_CONFIG=external-cmark` will try use the external package and will return an error if it couldn't find it.

For this option you must have pkg-config installed (build time dependency).