### PR TITLE
Minor changes

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -485,6 +485,8 @@ void BrowserTab::on_requestComplete(const QByteArray &ref_data, const QString &m
     this->current_stats.mime_type = mime;
     this->current_stats.loading_time = this->timer.elapsed();
     emit this->fileLoaded(this->current_stats);
+
+    this->updateMouseCursor(false);
 }
 
 void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
@@ -1263,6 +1265,8 @@ void BrowserTab::addProtocolHandler(std::unique_ptr<ProtocolHandler> &&handler)
 
 bool BrowserTab::startRequest(const QUrl &url, ProtocolHandler::RequestOptions options)
 {
+    this->updateMouseCursor(true);
+
     this->current_server_certificate = QSslCertificate { };
 
     this->current_handler = nullptr;
@@ -1357,6 +1361,14 @@ bool BrowserTab::startRequest(const QUrl &url, ProtocolHandler::RequestOptions o
     this->network_timeout_timer.start(kristall::options.network_timeout);
 
     return this->current_handler->startRequest(url.adjusted(QUrl::RemoveFragment), options);
+}
+
+void BrowserTab::updateMouseCursor(bool waiting)
+{
+    if (waiting)
+        this->ui->text_browser->setDefaultCursor(Qt::BusyCursor);
+    else
+        this->ui->text_browser->setDefaultCursor(Qt::ArrowCursor);
 }
 
 bool BrowserTab::enableClientCertificate(const CryptoIdentity &ident)

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -166,6 +166,8 @@ private:
 
     bool startRequest(QUrl const & url, ProtocolHandler::RequestOptions options);
 
+    void updateMouseCursor(bool waiting);
+
     bool enableClientCertificate(CryptoIdentity const & ident);
     void disableClientCertificate();
 public:

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -1,4 +1,5 @@
 #include "documentstyle.hpp"
+#include "kristall.hpp"
 #include <cassert>
 #include <QDebug>
 #include <QString>
@@ -115,7 +116,7 @@ static QString encodeCssFont (const QFont& refFont)
     return cssFontStr;
 }
 
-DocumentStyle::DocumentStyle() : theme(Fixed),
+DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     standard_font(),
     h1_font(),
     h2_font(),
@@ -135,21 +136,41 @@ DocumentStyle::DocumentStyle() : theme(Fixed),
     external_link_prefix("⇒ "),
     margin(55.0)
 {
-    preformatted_font.setFamily("monospace");
+    if (do_init) this->initialiseDefaultFonts();
+}
+
+void DocumentStyle::initialiseDefaultFonts()
+{
+    // Setup default fonts
+#ifdef Q_OS_WIN32
+    // Windows
+    static const QString FONT_NORMAL = "Segoe UI";
+    static const QString FONT_MONO = "Consolas";
+//#elif defined Q_OS_DARWIN
+    // Mac (No idea what they use)
+    // static const QString FONT_NORMAL = "???";
+    // static const QString FONT_MONO = "???";
+#else
+    // Ganoo slash linooks
+    static const QString FONT_NORMAL = kristall::default_font_family;
+    static const QString FONT_MONO = kristall::default_font_family_fixed;
+#endif
+
+    preformatted_font.setFamily(FONT_MONO);
     preformatted_font.setPointSizeF(10.0);
 
-    standard_font.setFamily("sans");
+    standard_font.setFamily(FONT_NORMAL);
     standard_font.setPointSizeF(10.0);
 
-    h1_font.setFamily("sans");
+    h1_font.setFamily(FONT_NORMAL);
     h1_font.setBold(true);
     h1_font.setPointSizeF(20.0);
 
-    h2_font.setFamily("sans");
+    h2_font.setFamily(FONT_NORMAL);
     h2_font.setBold(true);
     h2_font.setPointSizeF(15.0);
 
-    h3_font.setFamily("sans");
+    h3_font.setFamily(FONT_NORMAL);
     h3_font.setBold(true);
     h3_font.setPointSizeF(12.0);
 

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -14,7 +14,9 @@ struct DocumentStyle
         AutoLightTheme = 2
     };
 
-    DocumentStyle();
+    DocumentStyle(bool do_init = true);
+
+    void initialiseDefaultFonts();
 
     //! Calculates a filtered/legal file name with all non-allowed chars escaped
     static QString createFileNameFromName(QString const & src, int index);

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -116,6 +116,8 @@ namespace kristall
     void setTheme(Theme theme);
 
     void setUiDensity(UIDensity density, bool previewing);
+
+    extern QString default_font_family, default_font_family_fixed;
 }
 
 #endif // KRISTALL_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,9 @@ SslTrust            kristall::trust::gemini;
 SslTrust            kristall::trust::https;
 FavouriteCollection kristall::favourites;
 GenericSettings     kristall::options;
-DocumentStyle       kristall::document_style;
+DocumentStyle       kristall::document_style(false);
+QString             kristall::default_font_family;
+QString             kristall::default_font_family_fixed;
 
 QDir kristall::dirs::config_root;
 QDir kristall::dirs::cache_root;
@@ -90,6 +92,13 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(SSTR(KRISTALL_VERSION));
 
     ::app = &app;
+
+    {
+        // Initialise default fonts
+        kristall::default_font_family = QFontDatabase::systemFont(QFontDatabase::GeneralFont).family();
+        kristall::default_font_family_fixed = QFontInfo(QFont("monospace")).family();
+        kristall::document_style.initialiseDefaultFonts();
+    }
 
     kristall::clipboard = app.clipboard();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -442,8 +442,9 @@ void kristall::setTheme(Theme theme)
 #endif
 
         // Use "mid" colour for our URL bar dim colour:
-        kristall::options.fancy_urlbar_dim_colour
-            = app->palette().color(QPalette::Mid);
+        QColor col = app->palette().color(QPalette::WindowText);
+        col.setAlpha(150);
+        kristall::options.fancy_urlbar_dim_colour = std::move(col);
     }
     else if(theme == Theme::light)
     {

--- a/src/widgets/kristalltextbrowser.cpp
+++ b/src/widgets/kristalltextbrowser.cpp
@@ -28,7 +28,27 @@ void KristallTextBrowser::mouseReleaseEvent(QMouseEvent *event)
     }
 }
 
+void KristallTextBrowser::mouseMoveEvent(QMouseEvent *event)
+{
+    QTextBrowser::mouseMoveEvent(event);
+
+    // This slight hack allows us to set the "default" cursor,
+    // (i.e when not hovering over links) We need to do this
+    // because QTextBrowser for some reason resets viewport cursor
+    // to ArrowCursor after we hover over links
+    const QCursor& cur = this->viewport()->cursor();
+    if (cur != this->wanted_cursor && cur != Qt::PointingHandCursor)
+    {
+        this->viewport()->setCursor(wanted_cursor);
+    }
+}
+
 void KristallTextBrowser::on_anchorClicked(const QUrl &url)
 {
     emit this->anchorClicked(url, this->signal_new_tab);
+}
+
+void KristallTextBrowser::setDefaultCursor(const QCursor &cur)
+{
+    this->wanted_cursor = cur;
 }

--- a/src/widgets/kristalltextbrowser.cpp
+++ b/src/widgets/kristalltextbrowser.cpp
@@ -37,7 +37,8 @@ void KristallTextBrowser::mouseMoveEvent(QMouseEvent *event)
     // because QTextBrowser for some reason resets viewport cursor
     // to ArrowCursor after we hover over links
     const QCursor& cur = this->viewport()->cursor();
-    if (cur != this->wanted_cursor && cur != Qt::PointingHandCursor)
+    if (cur.shape() != this->wanted_cursor.shape() &&
+        cur.shape() != Qt::PointingHandCursor)
     {
         this->viewport()->setCursor(wanted_cursor);
     }

--- a/src/widgets/kristalltextbrowser.hpp
+++ b/src/widgets/kristalltextbrowser.hpp
@@ -12,6 +12,10 @@ public:
 
     void mouseReleaseEvent(QMouseEvent * event) override;
 
+    void mouseMoveEvent(QMouseEvent * event) override;
+
+    void setDefaultCursor(QCursor const & shape);
+
 signals:
     void anchorClicked(QUrl const &, bool open_in_new_tab);
 
@@ -20,6 +24,7 @@ private: // slots
 
 private:
     bool signal_new_tab = false;
+    QCursor wanted_cursor;
 };
 
 #endif // KRISTALLTEXTBROWSER_HPP


### PR DESCRIPTION
* 'busy' cursor is now used while a page is loading on the current tab. (should we make this optional?)
* URL bar highlight colour improved a bit
* Default fonts should be better now. Linux and Mac use a default system font. (**bug**: On Windows I've tried to get it to apply Consolas and Segoe UI by default but it doesn't seem to be using them for some reason. After opening the settings font dialog and pressing accept it does change though)