### PR TITLE
Apply favourites button workaround

### DIFF
--- a/src/browsertab.ui
+++ b/src/browsertab.ui
@@ -119,7 +119,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="fav_button">
+      <widget class="FavouriteButton" name="fav_button">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -291,6 +291,11 @@ p, li { white-space: pre-wrap; }
    <class>KristallTextBrowser</class>
    <extends>QTextBrowser</extends>
    <header>widgets/kristalltextbrowser.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>FavouriteButton</class>
+   <extends>QToolButton</extends>
+   <header>widgets/favouritebutton.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -119,7 +119,8 @@ SOURCES += \
     widgets/elidelabel.cpp \
     widgets/searchbar.cpp \
     widgets/ssltrusteditor.cpp \
-    widgets/favouritepopup.cpp
+    widgets/favouritepopup.cpp \
+    widgets/favouritebutton.cpp
 
 HEADERS += \
     ../lib/luis-l-gist/interactiveview.hpp \
@@ -163,7 +164,8 @@ HEADERS += \
     widgets/elidelabel.hpp \
     widgets/searchbar.hpp \
     widgets/ssltrusteditor.hpp \
-    widgets/favouritepopup.hpp
+    widgets/favouritepopup.hpp \
+    widgets/favouritebutton.hpp
 
 FORMS += \
   browsertab.ui \

--- a/src/widgets/favouritebutton.cpp
+++ b/src/widgets/favouritebutton.cpp
@@ -1,0 +1,17 @@
+#include "favouritebutton.hpp"
+
+#include <QStylePainter>
+#include <QStyleOptionToolButton>
+
+FavouriteButton::FavouriteButton(QWidget *parent)
+    : QToolButton(parent)
+{}
+
+void FavouriteButton::paintEvent(QPaintEvent *event)
+{
+    QStylePainter p(this);
+    QStyleOptionToolButton opt;
+    initStyleOption(&opt);
+    opt.features &= (~QStyleOptionToolButton::HasMenu);
+    p.drawComplexControl(QStyle::CC_ToolButton, opt);
+}

--- a/src/widgets/favouritebutton.hpp
+++ b/src/widgets/favouritebutton.hpp
@@ -1,0 +1,25 @@
+#ifndef FAVOURITE_BUTTON_HPP
+#define FAVOURITE_BUTTON_HPP
+
+//! This class is used to implement a workaround
+//! to get rid of the "little arrow" that Qt
+//! forces onto toolbuttons that have menus.
+//!
+//! https://bugreports.qt.io/browse/QTBUG-2036
+
+#include <QToolButton>
+#include <QtGui>
+
+class FavouriteButton : public QToolButton
+{
+    Q_OBJECT;
+public:
+    explicit FavouriteButton(QWidget * parent = 0);
+
+protected:
+    virtual void paintEvent(QPaintEvent * event);
+
+};
+
+
+#endif


### PR DESCRIPTION
Continues #109 
The width is still a little odd on OS default theme, but it looks perfect in kristall's light/dark themes. 