### PR TITLE
DocumentStyle: escape special chars when saving the style

### DIFF
--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -196,7 +196,7 @@ QString DocumentStyle::createFileNameFromName(const QString &src, int index)
             result.append('-');
         }
         else {
-            result.append(QString("").arg(c.unicode()));
+            result.append(QString::number(c.unicode()));
         }
     }
 


### PR DESCRIPTION
Before the change, the function printed "QString::arg: Argument missing"
to stderr when it saw special characters and omitted them from the file name.