### PR TITLE
Page caching

### DIFF
--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -53,7 +53,7 @@ public:
     explicit BrowserTab(MainWindow * mainWindow);
     ~BrowserTab();
 
-    void navigateTo(QUrl const & url, PushToHistory mode, bool no_read_cache = false);
+    void navigateTo(QUrl const & url, PushToHistory mode, bool no_cache_read = false);
 
     void navigateBack(const QModelIndex &history_index);
 
@@ -135,7 +135,7 @@ private: // network slots
 
     void on_requestProgress(qint64 transferred);
     void on_requestComplete(QByteArray const & data, QString const & mime);
-    void on_requestCompleteMime(QByteArray const & data, MimeType const & mime);
+    void on_requestComplete(QByteArray const & data, MimeType const & mime);
     void on_redirected(QUrl uri, bool is_permanent);
     void on_inputRequired(QString const & user_query, bool is_sensitive);
     void on_networkError(ProtocolHandler::NetworkError error, QString const & reason);
@@ -165,7 +165,7 @@ private:
         this->addProtocolHandler(std::make_unique<T>());
     }
 
-    bool startRequest(QUrl const & url, ProtocolHandler::RequestOptions options, bool no_read_cache = false);
+    bool startRequest(QUrl const & url, ProtocolHandler::RequestOptions options, bool no_cache_read = false);
 
     void updateMouseCursor(bool waiting);
 

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -53,7 +53,7 @@ public:
     explicit BrowserTab(MainWindow * mainWindow);
     ~BrowserTab();
 
-    void navigateTo(QUrl const & url, PushToHistory mode);
+    void navigateTo(QUrl const & url, PushToHistory mode, bool no_read_cache = false);
 
     void navigateBack(const QModelIndex &history_index);
 
@@ -135,6 +135,7 @@ private: // network slots
 
     void on_requestProgress(qint64 transferred);
     void on_requestComplete(QByteArray const & data, QString const & mime);
+    void on_requestCompleteMime(QByteArray const & data, MimeType const & mime);
     void on_redirected(QUrl uri, bool is_permanent);
     void on_inputRequired(QString const & user_query, bool is_sensitive);
     void on_networkError(ProtocolHandler::NetworkError error, QString const & reason);
@@ -164,7 +165,7 @@ private:
         this->addProtocolHandler(std::make_unique<T>());
     }
 
-    bool startRequest(QUrl const & url, ProtocolHandler::RequestOptions options);
+    bool startRequest(QUrl const & url, ProtocolHandler::RequestOptions options, bool no_read_cache = false);
 
     void updateMouseCursor(bool waiting);
 
@@ -211,6 +212,8 @@ public:
     QString page_title;
 
     bool no_url_style = false;
+
+    bool was_read_from_cache = false;
 };
 
 #endif // BROWSERTAB_HPP

--- a/src/cachehandler.cpp
+++ b/src/cachehandler.cpp
@@ -1,0 +1,53 @@
+#include "cachehandler.hpp"
+#include "kristall.hpp"
+
+#include <QDebug>
+
+void CacheHandler::push(const QUrl &url, const QByteArray &body, const MimeType &mime)
+{
+    QString urlstr = url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment);
+
+    if (this->page_cache.find(urlstr) != this->page_cache.end())
+    {
+        qDebug() << "Updating cached page";
+        auto pg = this->page_cache[urlstr];
+        pg->body = body;
+        pg->mime = mime;
+        return;
+    }
+
+    this->page_cache[urlstr] = std::make_shared<CachedPage>(url, body, mime);
+
+    qDebug() << "Pushed page to cache: " << url;
+
+    return;
+}
+
+std::shared_ptr<CachedPage> CacheHandler::find(const QString &url)
+{
+    if (this->page_cache.find(url) != this->page_cache.end())
+    {
+        return page_cache[url];
+    }
+    return nullptr;
+}
+
+std::shared_ptr<CachedPage> CacheHandler::find(const QUrl &url)
+{
+    return this->find(url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment));
+}
+
+bool CacheHandler::contains(const QString &url) const
+{
+    return this->page_cache.find(url) != this->page_cache.end();
+}
+
+bool CacheHandler::contains(const QUrl &url) const
+{
+    return this->contains(url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment));
+}
+
+CacheMap const& CacheHandler::getPages() const
+{
+    return this->page_cache;
+}

--- a/src/cachehandler.hpp
+++ b/src/cachehandler.hpp
@@ -4,8 +4,27 @@
 #include "mimeparser.hpp"
 #include <memory>
 #include <unordered_map>
+
 #include <QUrl>
+#include <QString>
 #include <QByteArray>
+#include <QtGlobal>
+
+// Need a QString hash implementation for Qt versions below 5.14
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <QHash>
+namespace std
+{
+    template<>
+    struct hash<QString>
+    {
+        std::size_t operator()(const QString& s) const noexcept
+        {
+            return (size_t)qHash(s);
+        }
+    };
+}
+#endif
 
 struct CachedPage
 {

--- a/src/cachehandler.hpp
+++ b/src/cachehandler.hpp
@@ -1,0 +1,48 @@
+#ifndef CACHEHANDLER_HPP
+#define CACHEHANDLER_HPP
+
+#include "mimeparser.hpp"
+#include <memory>
+#include <unordered_map>
+#include <QUrl>
+#include <QByteArray>
+
+struct CachedPage
+{
+    QUrl url;
+
+    QByteArray body;
+
+    MimeType mime;
+
+    int scroll_pos;
+
+    // also: maybe compress page contents? May test
+    // to see if it's worth it
+
+    CachedPage(const QUrl &url, const QByteArray &body, const MimeType &mime)
+        : url(url), body(body), mime(mime), scroll_pos(-1)
+    {}
+};
+
+typedef std::unordered_map<QString, std::shared_ptr<CachedPage>> CacheMap;
+
+class CacheHandler
+{
+public:
+    void push(QUrl const & url, QByteArray const & body, MimeType const & mime);
+
+    std::shared_ptr<CachedPage> find(QString const &url);
+    std::shared_ptr<CachedPage> find(QUrl const &url);
+
+    bool contains(QString const & url) const;
+    bool contains(QUrl const & url) const;
+
+    CacheMap const& getPages() const;
+
+private:
+    // In-memory cache storage.
+    CacheMap page_cache;
+};
+
+#endif

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -11,6 +11,7 @@
 #include "favouritecollection.hpp"
 #include "protocolsetup.hpp"
 #include "documentstyle.hpp"
+#include "cachehandler.hpp"
 
 enum class Theme : int
 {
@@ -91,6 +92,8 @@ namespace kristall
     extern GenericSettings options;
 
     extern DocumentStyle document_style;
+
+    extern CacheHandler cache;
 
     namespace trust {
         extern SslTrust gemini;

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -120,7 +120,8 @@ SOURCES += \
     widgets/searchbar.cpp \
     widgets/ssltrusteditor.cpp \
     widgets/favouritepopup.cpp \
-    widgets/favouritebutton.cpp
+    widgets/favouritebutton.cpp \
+    cachehandler.cpp
 
 HEADERS += \
     ../lib/luis-l-gist/interactiveview.hpp \
@@ -165,7 +166,8 @@ HEADERS += \
     widgets/searchbar.hpp \
     widgets/ssltrusteditor.hpp \
     widgets/favouritepopup.hpp \
-    widgets/favouritebutton.hpp
+    widgets/favouritebutton.hpp \
+    cachehandler.hpp
 
 FORMS += \
   browsertab.ui \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ SslTrust            kristall::trust::https;
 FavouriteCollection kristall::favourites;
 GenericSettings     kristall::options;
 DocumentStyle       kristall::document_style(false);
+CacheHandler        kristall::cache;
 QString             kristall::default_font_family;
 QString             kristall::default_font_family_fixed;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -209,6 +209,40 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
     }
 }
 
+std::shared_ptr<CachedPage> MainWindow::cacheFind(QString const &url)
+{
+    if (this->page_cache.find(url) != this->page_cache.end())
+    {
+        return page_cache[url];
+    }
+    return nullptr;
+}
+
+bool MainWindow::cacheContains(const QUrl &url) const
+{
+    QString urlstr = url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment);
+    return this->page_cache.find(urlstr) != this->page_cache.end();
+}
+
+void MainWindow::cachePage(const QUrl &url, const QByteArray &body, const MimeType &mime)
+{
+    QString urlstr = url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment);
+    if (this->page_cache.find(urlstr) != this->page_cache.end())
+    {
+        qDebug() << "Updating cached page";
+        auto pg = this->page_cache[urlstr];
+        pg->body = body;
+        pg->mime = mime;
+        return;
+    }
+
+    this->page_cache[urlstr] = std::make_shared<CachedPage>(url, body, mime);
+
+    qDebug() << "Cached page : " << url;
+
+    return;
+}
+
 void MainWindow::on_browser_tabs_currentChanged(int index)
 {
     if(index >= 0) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -209,40 +209,6 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
     }
 }
 
-std::shared_ptr<CachedPage> MainWindow::cacheFind(QString const &url)
-{
-    if (this->page_cache.find(url) != this->page_cache.end())
-    {
-        return page_cache[url];
-    }
-    return nullptr;
-}
-
-bool MainWindow::cacheContains(const QUrl &url) const
-{
-    QString urlstr = url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment);
-    return this->page_cache.find(urlstr) != this->page_cache.end();
-}
-
-void MainWindow::cachePage(const QUrl &url, const QByteArray &body, const MimeType &mime)
-{
-    QString urlstr = url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment);
-    if (this->page_cache.find(urlstr) != this->page_cache.end())
-    {
-        qDebug() << "Updating cached page";
-        auto pg = this->page_cache[urlstr];
-        pg->body = body;
-        pg->mime = mime;
-        return;
-    }
-
-    this->page_cache[urlstr] = std::make_shared<CachedPage>(url, body, mime);
-
-    qDebug() << "Cached page : " << url;
-
-    return;
-}
-
 void MainWindow::on_browser_tabs_currentChanged(int index)
 {
     if(index >= 0) {

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -5,7 +5,6 @@
 #include <QLabel>
 #include <QSettings>
 
-
 #include "favouritecollection.hpp"
 #include "renderers/geminirenderer.hpp"
 
@@ -20,24 +19,6 @@ QT_END_NAMESPACE
 class BrowserTab;
 
 enum class UIDensity : int;
-
-struct CachedPage
-{
-    QUrl url;
-
-    QByteArray body;
-
-    MimeType mime;
-
-    int scroll_pos;
-
-    // also: maybe compress page contents? May test
-    // to see if it's worth it
-
-    CachedPage(const QUrl &url, const QByteArray &body, const MimeType &mime)
-        : url(url), body(body), mime(mime), scroll_pos(-1)
-    {}
-};
 
 class MainWindow : public QMainWindow
 {
@@ -61,12 +42,6 @@ public:
     void setUiDensity(UIDensity density, bool previewing);
 
     void mousePressEvent(QMouseEvent *event) override;
-
-    std::shared_ptr<CachedPage> cacheFind(QString const &url);
-
-    bool cacheContains(QUrl const & url) const;
-
-    void cachePage(QUrl const & url, QByteArray const & body, MimeType const & mime);
 
 private slots:
     void on_browser_tabs_currentChanged(int index);
@@ -139,8 +114,5 @@ private:
     QLabel * file_size;
     QLabel * file_mime;
     QLabel * load_time;
-
-    // This is where we store our current in-memory cache.
-    std::unordered_map<QString, std::shared_ptr<CachedPage>> page_cache;
 };
 #endif // MAINWINDOW_HPP

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -21,6 +21,24 @@ class BrowserTab;
 
 enum class UIDensity : int;
 
+struct CachedPage
+{
+    QUrl url;
+
+    QByteArray body;
+
+    MimeType mime;
+
+    // TODO: last scroll position
+
+    // also: maybe compress page contents? May test
+    // to see if it's worth it
+
+    CachedPage(const QUrl &url, const QByteArray &body, const MimeType &mime)
+        : url(url), body(body), mime(mime)
+    {}
+};
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -43,6 +61,12 @@ public:
     void setUiDensity(UIDensity density, bool previewing);
 
     void mousePressEvent(QMouseEvent *event) override;
+
+    std::shared_ptr<CachedPage> cacheFind(QString const &url);
+
+    bool cacheContains(QUrl const & url) const;
+
+    void cachePage(QUrl const & url, QByteArray const & body, MimeType const & mime);
 
 private slots:
     void on_browser_tabs_currentChanged(int index);
@@ -115,5 +139,8 @@ private:
     QLabel * file_size;
     QLabel * file_mime;
     QLabel * load_time;
+
+    // This is where we store our current in-memory cache.
+    std::unordered_map<QString, std::shared_ptr<CachedPage>> page_cache;
 };
 #endif // MAINWINDOW_HPP

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -29,13 +29,13 @@ struct CachedPage
 
     MimeType mime;
 
-    // TODO: last scroll position
+    int scroll_pos;
 
     // also: maybe compress page contents? May test
     // to see if it's worth it
 
     CachedPage(const QUrl &url, const QByteArray &body, const MimeType &mime)
-        : url(url), body(body), mime(mime)
+        : url(url), body(body), mime(mime), scroll_pos(-1)
     {}
 };
 

--- a/src/protocols/abouthandler.cpp
+++ b/src/protocols/abouthandler.cpp
@@ -1,5 +1,6 @@
 #include "abouthandler.hpp"
 #include "kristall.hpp"
+#include "ioutil.hpp"
 
 #include <QUrl>
 #include <QFile>
@@ -45,6 +46,27 @@ bool AboutHandler::startRequest(const QUrl &url, ProtocolHandler::RequestOptions
                 document.append("=> " + fav.second->destination.toString().toUtf8() + " " + fav.second->title.toUtf8() + "\n");
             }
         }
+
+        emit this->requestComplete(document, "text/gemini");
+    }
+    else if (url.path() == "cache")
+    {
+        QByteArray document;
+        document.append("# Cache information\n");
+
+        auto& cache = kristall::cache.getPages();
+        long unsigned cache_usage = 0;
+        int cached_count = 0;
+        for (auto it = cache.begin(); it != cache.end(); ++it, ++cached_count)
+        {
+            cache_usage += (long unsigned)it->second->body.size();
+        }
+
+        document.append(QString(
+            "In-memory cache usage:\n"
+            "* %1 used\n"
+            "* %2 pages in cache\n")
+            .arg(IoUtil::size_human(cache_usage), QString::number(cached_count)));
 
         emit this->requestComplete(document, "text/gemini");
     }

--- a/src/protocols/abouthandler.cpp
+++ b/src/protocols/abouthandler.cpp
@@ -66,7 +66,7 @@ bool AboutHandler::startRequest(const QUrl &url, ProtocolHandler::RequestOptions
             "In-memory cache usage:\n"
             "* %1 used\n"
             "* %2 pages in cache\n")
-            .arg(IoUtil::size_human(cache_usage), QString::number(cached_count)));
+            .arg(IoUtil::size_human(cache_usage), QString::number(cached_count)).toUtf8());
 
         emit this->requestComplete(document, "text/gemini");
     }

--- a/src/widgets/kristalltextbrowser.cpp
+++ b/src/widgets/kristalltextbrowser.cpp
@@ -28,10 +28,32 @@ void KristallTextBrowser::mouseReleaseEvent(QMouseEvent *event)
     }
 }
 
+void KristallTextBrowser::on_anchorClicked(const QUrl &url)
+{
+    emit this->anchorClicked(url, this->signal_new_tab);
+}
+
+
 void KristallTextBrowser::mouseMoveEvent(QMouseEvent *event)
 {
     QTextBrowser::mouseMoveEvent(event);
+    this->updateCursor();
+}
 
+void KristallTextBrowser::setDefaultCursor(const QCursor &cur)
+{
+    this->wanted_cursor = cur;
+    this->updateCursor();
+}
+
+void KristallTextBrowser::focusInEvent(QFocusEvent *event)
+{
+    QTextBrowser::focusInEvent(event);
+    this->updateCursor();
+}
+
+void KristallTextBrowser::updateCursor()
+{
     // This slight hack allows us to set the "default" cursor,
     // (i.e when not hovering over links) We need to do this
     // because QTextBrowser for some reason resets viewport cursor
@@ -42,14 +64,4 @@ void KristallTextBrowser::mouseMoveEvent(QMouseEvent *event)
     {
         this->viewport()->setCursor(wanted_cursor);
     }
-}
-
-void KristallTextBrowser::on_anchorClicked(const QUrl &url)
-{
-    emit this->anchorClicked(url, this->signal_new_tab);
-}
-
-void KristallTextBrowser::setDefaultCursor(const QCursor &cur)
-{
-    this->wanted_cursor = cur;
 }

--- a/src/widgets/kristalltextbrowser.hpp
+++ b/src/widgets/kristalltextbrowser.hpp
@@ -14,6 +14,8 @@ public:
 
     void mouseMoveEvent(QMouseEvent * event) override;
 
+    void focusInEvent(QFocusEvent * event) override;
+
     void setDefaultCursor(QCursor const & shape);
 
 signals:
@@ -21,6 +23,9 @@ signals:
 
 private: // slots
     void on_anchorClicked(QUrl const & url);
+
+private:
+    void updateCursor();
 
 private:
     bool signal_new_tab = false;


### PR DESCRIPTION
* Implements a new in-memory caching system. Currently there is no limit - will be added later. Only text documents are cached (HTML _not included_ as these are usually a lot bigger in file size. This can be a preference too in future). Also, if the user has an active client certificate enabled in a tab, caching for that tab is temporarily disabled. This prevents breaking sites like gemini://astrobotany.mozz.us which serves different pages when a user has their certificate attached
* Implements #21 (for cached pages). When navigating to a cached site, the scroll position is remembered and re-loaded.
* Adds a new about:cache page which currently just shows cache usage statistics.
* Fixes two bugs related to the busy cursor added in #108