### PR TITLE
fixes for cache and favourites

### DIFF
--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -40,6 +40,19 @@ struct DocumentStats
     }
 };
 
+enum RequestFlags : int
+{
+    None = 0,
+
+    // Forces request to be made to server
+    // instead of reading from cache.
+    DontReadFromCache = 1,
+
+    // If the user navigated back/forward
+    // (i.e if using back/forward buttons in toolbar)
+    NavigatedBackOrForward = 2,
+};
+
 class BrowserTab : public QWidget
 {
     Q_OBJECT
@@ -53,7 +66,7 @@ public:
     explicit BrowserTab(MainWindow * mainWindow);
     ~BrowserTab();
 
-    void navigateTo(QUrl const & url, PushToHistory mode, bool no_cache_read = false);
+    void navigateTo(QUrl const & url, PushToHistory mode, RequestFlags flags = RequestFlags::None);
 
     void navigateBack(const QModelIndex &history_index);
 
@@ -165,7 +178,7 @@ private:
         this->addProtocolHandler(std::make_unique<T>());
     }
 
-    bool startRequest(QUrl const & url, ProtocolHandler::RequestOptions options, bool no_cache_read = false);
+    bool startRequest(QUrl const & url, ProtocolHandler::RequestOptions options, RequestFlags flags = RequestFlags::None);
 
     void updateMouseCursor(bool waiting);
 

--- a/src/cachehandler.cpp
+++ b/src/cachehandler.cpp
@@ -1,11 +1,13 @@
 #include "cachehandler.hpp"
 #include "kristall.hpp"
+#include "ioutil.hpp"
 
 #include <QDebug>
 
-void CacheHandler::push(const QUrl &url, const QByteArray &body, const MimeType &mime)
+void CacheHandler::push(const QUrl &u, const QByteArray &body, const MimeType &mime)
 {
-    QString urlstr = url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment);
+    QUrl url = IoUtil::uniformUrl(u);
+    QString urlstr = url.toString(QUrl::FullyEncoded);;
 
     if (this->page_cache.find(urlstr) != this->page_cache.end())
     {
@@ -34,7 +36,7 @@ std::shared_ptr<CachedPage> CacheHandler::find(const QString &url)
 
 std::shared_ptr<CachedPage> CacheHandler::find(const QUrl &url)
 {
-    return this->find(url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment));
+    return this->find(IoUtil::uniformUrlString(url));
 }
 
 bool CacheHandler::contains(const QString &url) const
@@ -44,7 +46,7 @@ bool CacheHandler::contains(const QString &url) const
 
 bool CacheHandler::contains(const QUrl &url) const
 {
-    return this->contains(url.toString(QUrl::FullyEncoded | QUrl::RemoveFragment));
+    return this->contains(IoUtil::uniformUrlString(url));
 }
 
 CacheMap const& CacheHandler::getPages() const

--- a/src/cachehandler.cpp
+++ b/src/cachehandler.cpp
@@ -18,7 +18,7 @@ void CacheHandler::push(const QUrl &u, const QByteArray &body, const MimeType &m
         return;
     }
 
-    this->page_cache[urlstr] = std::make_shared<CachedPage>(url, body, mime);
+    this->page_cache[urlstr] = std::make_shared<CachedPage>(u, body, mime);
 
     qDebug() << "Pushed page to cache: " << url;
 

--- a/src/cachehandler.hpp
+++ b/src/cachehandler.hpp
@@ -51,13 +51,16 @@ class CacheHandler
 public:
     void push(QUrl const & url, QByteArray const & body, MimeType const & mime);
 
-    std::shared_ptr<CachedPage> find(QString const &url);
     std::shared_ptr<CachedPage> find(QUrl const &url);
 
-    bool contains(QString const & url) const;
     bool contains(QUrl const & url) const;
 
     CacheMap const& getPages() const;
+
+private:
+    std::shared_ptr<CachedPage> find(QString const &url);
+
+    bool contains(QString const & url) const;
 
 private:
     // In-memory cache storage.

--- a/src/favouritecollection.cpp
+++ b/src/favouritecollection.cpp
@@ -99,7 +99,7 @@ void FavouriteCollection::load(QSettings &settings)
             auto fav = std::make_unique<FavouriteNode>();
 
             fav->favourite.title = settings.value("title").toString();
-            fav->favourite.destination = IoUtil::uniformUrl(settings.value("url").toUrl());
+            fav->favourite.destination = settings.value("url").toUrl();
 
             group->children.emplace_back(std::move(fav));
         }
@@ -187,7 +187,7 @@ bool FavouriteCollection::editFavouriteTitle(const QUrl &u, const QString &new_t
         for(auto const & ident : group->children)
         {
             FavouriteNode* node = &ident->as<FavouriteNode>();
-            if(node->favourite.destination == url)
+            if(IoUtil::uniformUrl(node->favourite.destination) == url)
             {
                 node->favourite.title = new_title;
                 return true;
@@ -199,7 +199,7 @@ bool FavouriteCollection::editFavouriteTitle(const QUrl &u, const QString &new_t
 
 void FavouriteCollection::editFavouriteDest(const QModelIndex &index, const QUrl &url)
 {
-    this->getMutableFavourite(index)->destination = IoUtil::uniformUrl(url);
+    this->getMutableFavourite(index)->destination = url;
 }
 
 Favourite FavouriteCollection::getFavourite(const QUrl &u) const
@@ -210,7 +210,7 @@ Favourite FavouriteCollection::getFavourite(const QUrl &u) const
         for(auto const & ident : group->children)
         {
             FavouriteNode* node = &ident->as<FavouriteNode>();
-            if(node->favourite.destination == url)
+            if(IoUtil::uniformUrl(node->favourite.destination) == url)
                 return node->favourite;
         }
     }
@@ -355,7 +355,7 @@ bool FavouriteCollection::containsUrl(const QUrl &u) const
     {
         for(auto const & ident : group->children)
         {
-            if(ident->as<FavouriteNode>().favourite.destination == url)
+            if(IoUtil::uniformUrl(ident->as<FavouriteNode>().favourite.destination) == url)
                 return true;
         }
     }
@@ -368,7 +368,7 @@ bool FavouriteCollection::addUnsorted(const QUrl &url, const QString &t)
         return false;
     return addFavourite(tr("Unsorted"), Favourite {
         t,
-        IoUtil::uniformUrl(url),
+        url,
     });
 }
 
@@ -381,7 +381,7 @@ bool FavouriteCollection::removeUrl(const QUrl &u)
         for(auto it = group->children.begin(); it != group->children.end(); ++it, ++index)
         {
             auto & fav = it->get()->as<FavouriteNode>();
-            if(fav.favourite.destination == url) {
+            if(IoUtil::uniformUrl(fav.favourite.destination) == url) {
                 beginRemoveRows(QModelIndex { }, index, index + 1);
 
                 group->children.erase(it);

--- a/src/favouritecollection.cpp
+++ b/src/favouritecollection.cpp
@@ -1,4 +1,5 @@
 #include "favouritecollection.hpp"
+#include "ioutil.hpp"
 
 #include <cassert>
 #include <QDebug>
@@ -98,7 +99,7 @@ void FavouriteCollection::load(QSettings &settings)
             auto fav = std::make_unique<FavouriteNode>();
 
             fav->favourite.title = settings.value("title").toString();
-            fav->favourite.destination = settings.value("url").toUrl();
+            fav->favourite.destination = IoUtil::uniformUrl(settings.value("url").toUrl());
 
             group->children.emplace_back(std::move(fav));
         }
@@ -178,8 +179,9 @@ void FavouriteCollection::editFavouriteTitle(const QModelIndex &index, const QSt
     this->getMutableFavourite(index)->title = title;
 }
 
-bool FavouriteCollection::editFavouriteTitle(const QUrl &url, const QString &new_title)
+bool FavouriteCollection::editFavouriteTitle(const QUrl &u, const QString &new_title)
 {
+    QUrl url = IoUtil::uniformUrl(u);
     for(auto const & group : this->root.children)
     {
         for(auto const & ident : group->children)
@@ -197,11 +199,12 @@ bool FavouriteCollection::editFavouriteTitle(const QUrl &url, const QString &new
 
 void FavouriteCollection::editFavouriteDest(const QModelIndex &index, const QUrl &url)
 {
-    this->getMutableFavourite(index)->destination = url;
+    this->getMutableFavourite(index)->destination = IoUtil::uniformUrl(url);
 }
 
-Favourite FavouriteCollection::getFavourite(const QUrl &url) const
+Favourite FavouriteCollection::getFavourite(const QUrl &u) const
 {
+    QUrl url = IoUtil::uniformUrl(u);
     for(auto const & group : this->root.children)
     {
         for(auto const & ident : group->children)
@@ -345,8 +348,9 @@ QVector<QPair<QString, Favourite const *>> FavouriteCollection::allFavourites() 
     return identities;
 }
 
-bool FavouriteCollection::containsUrl(const QUrl &url) const
+bool FavouriteCollection::containsUrl(const QUrl &u) const
 {
+    QUrl url = IoUtil::uniformUrl(u);
     for(auto const & group : this->root.children)
     {
         for(auto const & ident : group->children)
@@ -364,12 +368,13 @@ bool FavouriteCollection::addUnsorted(const QUrl &url, const QString &t)
         return false;
     return addFavourite(tr("Unsorted"), Favourite {
         t,
-        url,
+        IoUtil::uniformUrl(url),
     });
 }
 
-bool FavouriteCollection::removeUrl(const QUrl &url)
+bool FavouriteCollection::removeUrl(const QUrl &u)
 {
+    QUrl url = IoUtil::uniformUrl(u);
     for(auto const & group : this->root.children)
     {
         size_t index = 0;

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -34,3 +34,18 @@ QString IoUtil::size_human(qint64 size)
     }
     return QString().setNum(num,'f',2)+" "+unit;
 }
+
+QUrl IoUtil::uniformUrl(QUrl url)
+{
+    // We have to manually strip the root path slash
+    // since StripTrailingSlash doesn't strip it for some reason.
+    if (url.path() == "/") url.setPath(QString { });
+
+    // This will strip slashes from non-root paths
+    return url.adjusted(QUrl::RemoveFragment | QUrl::StripTrailingSlash);
+}
+
+QString IoUtil::uniformUrlString(QUrl url)
+{
+    return IoUtil::uniformUrl(url).toString(QUrl::FullyEncoded);
+}

--- a/src/ioutil.hpp
+++ b/src/ioutil.hpp
@@ -2,12 +2,16 @@
 #define IOUTIL_HPP
 
 #include <QIODevice>
+#include <QUrl>
 
 struct IoUtil
 {
     static bool writeAll(QIODevice & dst, QByteArray const & src);
 
     static QString size_human(qint64 size);
+
+    static QUrl uniformUrl(QUrl url);
+    static QString uniformUrlString(QUrl url);
 };
 
 #endif // IOUTIL_HPP


### PR DESCRIPTION
* URLs in cache are now saved *without trailing slashes*, so that if a user has e.g `gemini://example.com` in their cache, and they navigate to `gemini://example.com/` (note trailing slash) the page will be read from the cache. This was done using a new method `uniformUrl` in the `IoUtil` class (should we move it somewhere else?)
* Same fix was applied to favourites as they had the same bug.
* Pages now only scroll back to their old scroll pos if the user navigates to them via back/forward buttons or through history. This makes navigating sites less confusing when they click links to pages they've already visited.