### PR TITLE
cache limits

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1471,6 +1471,7 @@ bool BrowserTab::startRequest(const QUrl &url, ProtocolHandler::RequestOptions o
     }
 
     // Check if we have the page in our cache.
+    kristall::cache.clean();
     if (auto pg = kristall::cache.find(url); pg != nullptr)
     {
         qDebug() << "Reading page from cache";

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -587,11 +587,6 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
         document->setHtml(page_html);
 
         page_title = document->metaInformation(QTextDocument::DocumentTitle);
-
-        // For now we don't cache HTML pages, because they will most
-        // of the time clog up the cache.
-        // TODO: preference for this? protocol-specific cache limits?
-        will_cache = false;
     }
     else if (not plaintext_only and mime.is("text","x-kristall-theme"))
     {

--- a/src/cachehandler.cpp
+++ b/src/cachehandler.cpp
@@ -15,12 +15,10 @@ void CacheHandler::push(const QUrl &u, const QByteArray &body, const MimeType &m
     }
 
     // Pop cached items until we are below the cache limit
-    // TODO
-    //if ((bodysize + this->size()) > (kristall::options.cache_limit * 1024 * 1024))
-    //while ((bodysize + this->size()) > (kristall::options.cache_limit * 1024 * 1024))
-    //{
-    //    qDebug() << "cache: adding item will exceed cache limit";
-    //}
+    while ((bodysize + this->size()) > (kristall::options.cache_limit * 1024))
+    {
+        this->popOldest();
+    }
 
     QUrl url = IoUtil::uniformUrl(u);
     QString urlstr = url.toString(QUrl::FullyEncoded);;
@@ -105,4 +103,33 @@ void CacheHandler::clean()
 CacheMap const& CacheHandler::getPages() const
 {
     return this->page_cache;
+}
+
+void CacheHandler::popOldest()
+{
+    if (this->page_cache.size() == 0)
+    {
+        return;
+    }
+
+    // This will iterate over the cache map,
+    // find the key with the oldest timestamp,
+    // and erase it from the map.
+    //
+    // (TODO: make this more efficient somehow?)
+
+    QDateTime oldest = QDateTime::currentDateTime();
+    QString oldest_key;
+    for (auto it = this->page_cache.begin(); it != this->page_cache.end(); ++it)
+    {
+        if (it->second->time_cached < oldest)
+        {
+            oldest = it->second->time_cached;
+            oldest_key = it->first;
+        }
+    }
+
+    // Erase it from the map
+    qDebug() << "cache: popping " << oldest_key;
+    this->page_cache.erase(oldest_key);
 }

--- a/src/cachehandler.hpp
+++ b/src/cachehandler.hpp
@@ -48,7 +48,7 @@ struct CachedPage
     {}
 };
 
-// TODO: move away from the 'unordered_map' type?
+// Maybe unordered_map isn't the best type for this?
 typedef std::unordered_map<QString, std::shared_ptr<CachedPage>> CacheMap;
 
 class CacheHandler
@@ -70,6 +70,8 @@ private:
     std::shared_ptr<CachedPage> find(QString const &url);
 
     bool contains(QString const & url);
+
+    void popOldest();
 
 private:
     // In-memory cache storage.

--- a/src/cachehandler.hpp
+++ b/src/cachehandler.hpp
@@ -9,6 +9,7 @@
 #include <QString>
 #include <QByteArray>
 #include <QtGlobal>
+#include <QDateTime>
 
 // Need a QString hash implementation for Qt versions below 5.14
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
@@ -36,14 +37,18 @@ struct CachedPage
 
     int scroll_pos;
 
+    QDateTime time_cached;
+
     // also: maybe compress page contents? May test
     // to see if it's worth it
 
-    CachedPage(const QUrl &url, const QByteArray &body, const MimeType &mime)
-        : url(url), body(body), mime(mime), scroll_pos(-1)
+    CachedPage(const QUrl &url, const QByteArray &body,
+        const MimeType &mime, const QDateTime &cached)
+        : url(url), body(body), mime(mime), scroll_pos(-1), time_cached(cached)
     {}
 };
 
+// TODO: move away from the 'unordered_map' type?
 typedef std::unordered_map<QString, std::shared_ptr<CachedPage>> CacheMap;
 
 class CacheHandler
@@ -53,14 +58,18 @@ public:
 
     std::shared_ptr<CachedPage> find(QUrl const &url);
 
-    bool contains(QUrl const & url) const;
+    bool contains(QUrl const & url);
+
+    int size();
+
+    void clean();
 
     CacheMap const& getPages() const;
 
 private:
     std::shared_ptr<CachedPage> find(QString const &url);
 
-    bool contains(QString const & url) const;
+    bool contains(QString const & url);
 
 private:
     // In-memory cache storage.

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -250,6 +250,10 @@ void SettingsDialog::setOptions(const GenericSettings &options)
     this->ui->network_timeout->setValue(this->current_options.network_timeout);
 
     this->ui->enable_home_btn->setChecked(this->current_options.enable_home_btn);
+
+    this->ui->cache_limit->setValue(this->current_options.cache_limit);
+    this->ui->cache_threshold->setValue(this->current_options.cache_threshold);
+    this->ui->cache_life->setValue(this->current_options.cache_life);
 }
 
 GenericSettings SettingsDialog::options() const
@@ -660,8 +664,7 @@ void SettingsDialog::on_redirection_mode_currentIndexChanged(int index)
     this->current_options.redirection_policy = GenericSettings::RedirectionWarning(this->ui->redirection_mode->itemData(index).toInt());
 }
 
-void SettingsDialog::on_max_redirects_valueChanged(int max_redirections)
-{
+void SettingsDialog::on_max_redirects_valueChanged(int max_redirections) {
     this->current_options.max_redirections = max_redirections;
 }
 
@@ -673,4 +676,19 @@ void SettingsDialog::on_network_timeout_valueChanged(int timeout)
 void SettingsDialog::on_enable_home_btn_clicked(bool checked)
 {
     this->current_options.enable_home_btn = checked;
+}
+
+void SettingsDialog::on_cache_limit_valueChanged(int limit)
+{
+    this->current_options.cache_limit = limit;
+}
+
+void SettingsDialog::on_cache_threshold_valueChanged(int thres)
+{
+    this->current_options.cache_threshold = thres;
+}
+
+void SettingsDialog::on_cache_life_valueChanged(int life)
+{
+    this->current_options.cache_life = life;
 }

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -132,6 +132,12 @@ private slots:
 
     void on_enable_home_btn_clicked(bool arg1);
 
+    void on_cache_limit_valueChanged(int limit);
+
+    void on_cache_threshold_valueChanged(int thres);
+
+    void on_cache_life_valueChanged(int life);
+
 private:
     void reloadStylePreview();
 

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -371,6 +371,79 @@
          </property>
         </widget>
        </item>
+
+       <item row="14" column="0">
+        <widget class="QLabel" name="label_30">
+         <property name="text">
+          <string>Total cache size limit</string>
+         </property>
+         <property name="toolTip">
+          <string>The total amount of memory that can be occupied by cached items. Set to zero to disable in-memory caching.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1">
+        <widget class="QSpinBox" name="cache_limit">
+         <property name="suffix">
+          <string> MiB</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>4000</number>
+         </property>
+        </widget>
+       </item>
+
+       <item row="15" column="0">
+        <widget class="QLabel" name="label_31">
+         <property name="text">
+          <string>Cached item size threshold</string>
+         </property>
+         <property name="toolTip">
+          <string>Items which are below this threshold are cached in memory. Any above are simply discarded.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1">
+        <widget class="QSpinBox" name="cache_threshold">
+         <property name="suffix">
+          <string> KiB</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>102400</number>
+         </property>
+        </widget>
+       </item>
+
+       <item row="16" column="0">
+        <widget class="QLabel" name="label_31">
+         <property name="text">
+          <string>Cached item life</string>
+         </property>
+         <property name="toolTip">
+          <string>How long cached items last before they are expired and require a reload.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="1">
+        <widget class="QSpinBox" name="cache_life">
+         <property name="suffix">
+          <string> minutes</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>8760</number>
+         </property>
+        </widget>
+       </item>
+
       </layout>
      </widget>
      <widget class="QWidget" name="style_tab">

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -385,13 +385,13 @@
        <item row="14" column="1">
         <widget class="QSpinBox" name="cache_limit">
          <property name="suffix">
-          <string> MiB</string>
+          <string> KiB</string>
          </property>
          <property name="minimum">
           <number>0</number>
          </property>
          <property name="maximum">
-          <number>4000</number>
+          <number>4000000</number>
          </property>
         </widget>
        </item>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -62,6 +62,11 @@ struct GenericSettings
     // Additional toolbar items
     bool enable_home_btn = false;
 
+    // In-memory caching
+    int cache_limit = 100;
+    int cache_threshold = 50;
+    int cache_life = 10;
+
     void load(QSettings & settings);
     void save(QSettings & settings) const;
 };

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -63,9 +63,9 @@ struct GenericSettings
     bool enable_home_btn = false;
 
     // In-memory caching
-    int cache_limit = 100;
-    int cache_threshold = 50;
-    int cache_life = 10;
+    int cache_limit = 1000;
+    int cache_threshold = 125;
+    int cache_life = 15;
 
     void load(QSettings & settings);
     void save(QSettings & settings) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,8 +369,8 @@ void GenericSettings::load(QSettings &settings)
 
     enable_home_btn = settings.value("enable_home_btn", false).toBool();
 
-    cache_limit = settings.value("cache_limit", 100).toInt();
-    cache_threshold = settings.value("cache_threshold", 200).toInt();
+    cache_limit = settings.value("cache_limit", 1000).toInt();
+    cache_threshold = settings.value("cache_threshold", 125).toInt();
     cache_life = settings.value("cache_life", 15).toInt();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,6 +368,10 @@ void GenericSettings::load(QSettings &settings)
     redirection_policy = RedirectionWarning(settings.value("redirection_policy ", WarnOnHostChange).toInt());
 
     enable_home_btn = settings.value("enable_home_btn", false).toBool();
+
+    cache_limit = settings.value("cache_limit", 100).toInt();
+    cache_threshold = settings.value("cache_threshold", 200).toInt();
+    cache_life = settings.value("cache_life", 15).toInt();
 }
 
 void GenericSettings::save(QSettings &settings) const
@@ -398,6 +402,10 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("redirection_policy", int(redirection_policy));
     settings.setValue("network_timeout", network_timeout);
     settings.setValue("enable_home_btn", enable_home_btn);
+
+    settings.setValue("cache_limit", cache_limit);
+    settings.setValue("cache_threshold", cache_threshold);
+    settings.setValue("cache_life", cache_life);
 }
 
 


### PR DESCRIPTION
This implements in-memory caching limits, which can all be adjusted in preferences:
* total cache size
* cached item size threshold (any loaded items above this are not cached)
* cached item life

The 'total cache' works by popping the oldest items in the cache map if adding the current page would exceed the limit. This was a bit of a hack to implement since we are using an unordered_map for the cache map. I feel like the unordered_map works best for just about everything else except this. 
Nevertheless - it works fine :smiley: 

HTML items are now also cached, as the size shouldn't be too much of an issue with the new limits - any massive pages over the configured limit simply would not be cached