### PR TITLE
Status bar updates

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -552,11 +552,20 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
     // Only cache text pages
     bool will_cache = true;
 
+    // We always give trailing slashes to the renderers
+    // since QUrl.resolve will not create absolute URLs properly
+    // without them.
+    QUrl cur_url = current_location;
+    if (cur_url.path().isEmpty())
+        cur_url.setPath("/");
+    else if (cur_url.path()[cur_url.path().length() - 1] != "/")
+        cur_url.setPath(cur_url.path() + "/");
+
     if (not plaintext_only and mime.is("text", "gemini"))
     {
         document = GeminiRenderer::render(
             data,
-            this->current_location,
+            cur_url,
             doc_style,
             this->outline,
             &this->page_title);
@@ -565,7 +574,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
     {
         document = GophermapRenderer::render(
             data,
-            this->current_location,
+            cur_url,
             doc_style);
     }
     else if (not plaintext_only and mime.is("text","html"))
@@ -611,7 +620,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
 
         document = GeminiRenderer::render(
             src.readAll(),
-            this->current_location,
+            cur_url,
             preview_style,
             this->outline);
 
@@ -624,7 +633,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
     {
         document = MarkdownRenderer::render(
             data,
-            this->current_location,
+            cur_url,
             doc_style,
             this->outline,
             this->page_title);
@@ -671,7 +680,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
     else if (mime.is("video") or mime.is("audio"))
     {
         doc_type = Media;
-        this->ui->media_browser->setMedia(data, this->current_location, mime.type);
+        this->ui->media_browser->setMedia(data, cur_url, mime.type);
 
         will_cache = false;
     }
@@ -713,7 +722,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
 
         document = GeminiRenderer::render(
             page_data.toUtf8(),
-            this->current_location,
+            cur_url,
             doc_style,
             this->outline,
             &this->page_title);

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -516,6 +516,7 @@ void BrowserTab::on_requestComplete(const QByteArray &ref_data, const MimeType &
     this->current_stats.file_size = ref_data.size();
     this->current_stats.mime_type = mime;
     this->current_stats.loading_time = this->timer.elapsed();
+    this->current_stats.loaded_from_cache = was_read_from_cache;
     emit this->fileLoaded(this->current_stats);
 
     this->updateMouseCursor(false);
@@ -1171,6 +1172,7 @@ void BrowserTab::on_requestProgress(qint64 transferred)
     this->current_stats.file_size = transferred;
     this->current_stats.mime_type = MimeType { };
     this->current_stats.loading_time = this->timer.elapsed();
+    this->current_stats.loaded_from_cache = false;
     emit this->fileLoaded(this->current_stats);
 
     this->network_timeout_timer.stop();

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -520,6 +520,9 @@ void BrowserTab::on_requestComplete(const QByteArray &ref_data, const MimeType &
     emit this->fileLoaded(this->current_stats);
 
     this->updateMouseCursor(false);
+
+    emit this->requestStateChanged(RequestState::None);
+    this->request_state = RequestState::None;
 }
 
 void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
@@ -1355,6 +1358,10 @@ void BrowserTab::addProtocolHandler(std::unique_ptr<ProtocolHandler> &&handler)
     connect(handler.get(), &ProtocolHandler::requestProgress, this, &BrowserTab::on_requestProgress);
     connect(handler.get(), &ProtocolHandler::requestComplete, this,
         qOverload<QByteArray const &, QString const &>(&BrowserTab::on_requestComplete));
+    connect(handler.get(), &ProtocolHandler::requestStateChange, this, [this](RequestState state) {
+        emit this->requestStateChanged(state);
+        this->request_state = state;
+    });
     connect(handler.get(), &ProtocolHandler::redirected, this, &BrowserTab::on_redirected);
     connect(handler.get(), &ProtocolHandler::inputRequired, this, &BrowserTab::on_inputRequired);
     connect(handler.get(), &ProtocolHandler::networkError, this, &BrowserTab::on_networkError);

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -34,6 +34,7 @@ struct DocumentStats
     int loading_time = 0; // in ms
     MimeType mime_type;
     qint64 file_size = 0;
+    bool loaded_from_cache = false;
 
     bool isValid() const {
         return mime_type.isValid();

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -105,6 +105,7 @@ signals:
     void titleChanged(QString const & title);
     void locationChanged(QUrl const & url);
     void fileLoaded(DocumentStats const & stats);
+    void requestStateChanged(RequestState state);
 
 private slots:
     void on_url_bar_returnPressed();
@@ -228,6 +229,8 @@ public:
     bool no_url_style = false;
 
     bool was_read_from_cache = false;
+
+    RequestState request_state;
 };
 
 #endif // BROWSERTAB_HPP

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -26,6 +26,16 @@ enum class UIDensity : int
     classic = 1
 };
 
+enum class RequestState : int
+{
+    None = 0,
+    Started = 1,
+    HostFound = 2,
+    Connected = 3,
+
+    StartedWeb = 255,
+};
+
 struct GenericSettings
 {
     enum TextDisplay {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -24,6 +24,7 @@ MainWindow::MainWindow(QApplication * app, QWidget *parent) :
     ui(new Ui::MainWindow),
     url_status(new ElideLabel(this)),
     file_size(new QLabel(this)),
+    file_cached(new QLabel(this)),
     file_mime(new QLabel(this)),
     load_time(new QLabel(this))
 {
@@ -32,6 +33,7 @@ MainWindow::MainWindow(QApplication * app, QWidget *parent) :
     this->url_status->setElideMode(Qt::ElideMiddle);
 
     this->statusBar()->addWidget(this->url_status);
+    this->statusBar()->addPermanentWidget(this->file_cached);
     this->statusBar()->addPermanentWidget(this->file_mime);
     this->statusBar()->addPermanentWidget(this->file_size);
     this->statusBar()->addPermanentWidget(this->load_time);
@@ -419,10 +421,12 @@ void MainWindow::setFileStatus(const DocumentStats &stats)
 {
     if(stats.isValid()) {
         this->file_size->setText(IoUtil::size_human(stats.file_size));
-        this->file_mime->setText(stats.mime_type.toString());
+        this->file_cached->setText(stats.loaded_from_cache ? "(cached)" : "");
+        this->file_mime->setText(stats.mime_type.toString(false));
         this->load_time->setText(QString("%1 ms").arg(stats.loading_time));
     } else {
         this->file_size->setText("");
+        this->file_cached->setText("");
         this->file_mime->setText("");
         this->load_time->setText("");
     }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -114,6 +114,7 @@ private:
 
     ElideLabel * url_status;
     QLabel * file_size;
+    QLabel * file_cached;
     QLabel * file_mime;
     QLabel * load_time;
 };

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -20,6 +20,8 @@ class BrowserTab;
 
 enum class UIDensity : int;
 
+enum class RequestState : int;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -96,6 +98,8 @@ private: // slots
 
     void on_tab_fileLoaded(DocumentStats const & stats);
 
+    void on_tab_requestStateChanged(RequestState state);
+
     void on_tab_titleChanged(QString const & title);
 
     void on_tab_locationChanged(QUrl const & url);
@@ -105,6 +109,8 @@ private: // slots
 
 private:
     void setFileStatus(DocumentStats const & stats);
+
+    void setRequestState(RequestState state);
 
 public:
     QApplication * application;
@@ -117,5 +123,8 @@ private:
     QLabel * file_cached;
     QLabel * file_mime;
     QLabel * load_time;
+
+    QString request_status;
+    bool previewing_url = false;
 };
 #endif // MAINWINDOW_HPP

--- a/src/mimeparser.cpp
+++ b/src/mimeparser.cpp
@@ -20,18 +20,23 @@ QString MimeType::parameter(const QString &param_name, QString const & default_v
     return val;
 }
 
-QString MimeType::toString() const
+QString MimeType::toString(bool full) const
 {
     if(isValid()) {
         QString result = type;
         if(not subtype.isEmpty())
             result += "/" + subtype;
-        for(auto const & key : parameters.keys()) {
-            result += "; ";
-            result += key;
-            result += "=";
-            result += parameters[key];
+
+        if (full)
+        {
+            for(auto const & key : parameters.keys()) {
+                result += "; ";
+                result += key;
+                result += "=";
+                result += parameters[key];
+            }
         }
+
         return result;
     } else {
         return QString { };

--- a/src/mimeparser.hpp
+++ b/src/mimeparser.hpp
@@ -19,7 +19,7 @@ struct MimeType
         return not type.isEmpty();
     }
 
-    QString toString() const;
+    QString toString(bool full = true) const;
 };
 
 struct MimeParser

--- a/src/protocolhandler.hpp
+++ b/src/protocolhandler.hpp
@@ -6,6 +6,8 @@
 #include <QObject>
 #include <QAbstractSocket>
 
+enum class RequestState : int;
+
 class ProtocolHandler : public QObject
 {
     Q_OBJECT
@@ -49,6 +51,9 @@ signals:
 
     //! The request completed with the given data and mime type
     void requestComplete(QByteArray const & data, QString const & mime);
+
+    //! The state of the request has changed
+    void requestStateChange(RequestState state);
 
     //! Server redirected us to another URL
     void redirected(QUrl const & uri, bool is_permanent);

--- a/src/protocols/geminiclient.cpp
+++ b/src/protocols/geminiclient.cpp
@@ -19,6 +19,18 @@ GeminiClient::GeminiClient() : ProtocolHandler(nullptr)
 #else
     connect(&socket, QOverload<QAbstractSocket::SocketError>::of(&QTcpSocket::error), this, &GeminiClient::socketError);
 #endif
+
+    // States
+    connect(&socket, &QAbstractSocket::hostFound, this, [this]() {
+        emit this->requestStateChange(RequestState::HostFound);
+    });
+    connect(&socket, &QAbstractSocket::connected, this, [this]() {
+        emit this->requestStateChange(RequestState::Connected);
+    });
+    connect(&socket, &QAbstractSocket::disconnected, this, [this]() {
+        emit this->requestStateChange(RequestState::None);
+    });
+    emit this->requestStateChange(RequestState::None);
 }
 
 GeminiClient::~GeminiClient()
@@ -44,6 +56,8 @@ bool GeminiClient::startRequest(const QUrl &url, RequestOptions options)
         if(not socket.waitForDisconnected(1500))
             return false;
     }
+
+    emit this->requestStateChange(RequestState::Started);
 
     this->is_error_state = false;
 

--- a/src/protocols/webclient.cpp
+++ b/src/protocols/webclient.cpp
@@ -9,6 +9,8 @@ WebClient::WebClient() :
     current_reply(nullptr)
 {
     manager.setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    emit this->requestStateChange(RequestState::None);
 }
 
 WebClient::~WebClient()
@@ -28,6 +30,8 @@ bool WebClient::startRequest(const QUrl &url, RequestOptions options)
 
     if(this->current_reply != nullptr)
         return true;
+
+    emit this->requestStateChange(RequestState::StartedWeb);
 
     this->options = options;
     this->body.clear();
@@ -101,6 +105,8 @@ void WebClient::on_data()
 
 void WebClient::on_finished()
 {
+    emit this->requestStateChange(RequestState::None);
+
     emit this->hostCertificateLoaded(this->current_reply->sslConfiguration().peerCertificate());
 
     auto * const reply = this->current_reply;


### PR DESCRIPTION
* Status bar now displays an indicator that the loaded page is cached. it appears to the left of the page mime type.
* The mime type that is displayed in the status bar now only displays the type/subtype (e.g text/gemini) without any additional parameters, like `lang=...` stuff. I felt like a user wouldn't necessarily need to see that extra stuff
* The status bar now displays some loading information on tabs that are loading (looking up..., connecting..., etc) . This text is in place of where URL previews appear - however URL previews are prioritised over the loading status. (The implementation for HTTP is less informative than the other protocols, as it uses the QNetworkReply which doesn't provide much useful signals)
* Fixes a strange bug where if you navigate to a site (e.g gemini://rawtext.club:1965/~sloum/geminilist ) and don't include a trailing slash (this is only possible due to the caching - normally the site would redirect you to include the trailing slash) any local links on the page would direct to the wrong locations, because QUrl::resolved in the rendering code seems to only work properly if the root url ends with a trailing slash. This is fixed by manually ensuring that all links passed to the renderers have a trailing slash in them