### PR TITLE
BrowserTab: fix showing an empty redirect question box

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -865,7 +865,7 @@ void BrowserTab::on_redirected(QUrl uri, bool is_permanent)
             ).arg(uri.host());
         }
 
-        if(is_cross_protocol or is_cross_host)
+        if (!question.isEmpty())
         {
             auto answer = QMessageBox::question(
                 this,


### PR DESCRIPTION
The question box was showed when the redirect has a different scheme or host, without checking first if you want to see the it, which could lead to an empty dialog box instead of skipping it entirely.