### PR TITLE
Fixes for ANSI escape codes and allow to modify that 16 color palette

### DIFF
--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -134,7 +134,11 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     cross_scheme_link_color(0x09, 0x60, 0xa7),
     internal_link_prefix("→ "),
     external_link_prefix("⇒ "),
-    margin(55.0)
+    margin(55.0),
+    ansi_colors({"black", "darkred", "darkgreen", "darkgoldenrod",
+        "darkblue", "darkmagenta", "darkcyan", "lightgray",
+        "gray", "red", "green", "goldenrod",
+        "lightblue", "magenta", "cyan", "white"})
 {
     if (do_init) this->initialiseDefaultFonts();
 }
@@ -216,6 +220,8 @@ bool DocumentStyle::save(QSettings &settings) const
     settings.setValue("blockquote_color", blockquote_color.name());
 
     settings.setValue("margins", margin);
+
+    settings.setValue("ansi_colors", ansi_colors);
 
     {
         settings.beginGroup("Standard");
@@ -302,6 +308,12 @@ bool DocumentStyle::load(QSettings &settings)
         blockquote_color = QColor { settings.value("blockquote_color", blockquote_color.name()).toString() };
 
         margin = settings.value("margins", 55).toInt();
+
+        QStringList default_colors = {"black", "darkred", "darkgreen", "darkgoldenrod",
+            "darkblue", "darkmagenta", "darkcyan", "lightgray",
+            "gray", "red", "green", "goldenrod",
+            "lightblue", "magenta", "cyan", "white"};
+        ansi_colors = settings.value("ansi_colors", default_colors).toStringList();
 
         {
             settings.beginGroup("Standard");

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -51,6 +51,8 @@ struct DocumentStyle
 
     double margin;
 
+    QStringList ansi_colors;
+
     bool save(QSettings & settings) const;
     bool load(QSettings & settings);
 

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -164,10 +164,6 @@ void parseSGR(
                     {
                         ++it;
                         const auto colNum = *it;
-                        if (colNum == 124)
-                        {
-                            setColor(format, colNum);
-                        }
                         setColor(format, colNum);
                     }
                     else if (colMode == 2)

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -158,12 +158,10 @@ void parseSGR(
             case SetForeground:
                 if (args.size() > 2)
                 {
-                    ++it;
-                    const auto colMode = *it;
+                    const auto colMode = *++it;
                     if (colMode == 5)
                     {
-                        ++it;
-                        const auto colNum = *it;
+                        const auto colNum = *++it;
                         setColor(format, colNum);
                     }
                     else if (colMode == 2)
@@ -172,10 +170,8 @@ void parseSGR(
                         if (args.size() >= 4)
                         {
                             const auto red = *it;
-                            ++it;
-                            const auto green = *it;
-                            ++it;
-                            const auto blue = *it;
+                            const auto green = *++it;
+                            const auto blue = *++it;
                             format.setForeground(QColor(red, green, blue));
                         }
                     }
@@ -187,12 +183,10 @@ void parseSGR(
             case SetBackground:
                 if (args.size() > 2)
                 {
-                    ++it;
-                    const auto colMode = *it;
+                    const auto colMode = *++it;
                     if (colMode == 5)
                     {
-                        ++it;
-                        const auto colNum = *it;
+                        const auto colNum = *++it;
                         setColor(format, colNum, true);
                     }
                     else if (colMode == 2)
@@ -201,10 +195,8 @@ void parseSGR(
                         if (args.size() >= 4)
                         {
                             const auto red = *it;
-                            ++it;
-                            const auto green = *it;
-                            ++it;
-                            const auto blue = *it;
+                            const auto green = *++it;
+                            const auto blue = *++it;
                             format.setBackground(QColor(red, green, blue));
                         }
                     }

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -9,6 +9,7 @@
  *       https://en.wikipedia.org/wiki/VT52#Escape_sequences
  */
 #include "renderhelpers.hpp"
+#include "kristall.hpp"
 
 #include <QByteArray>
 #include <QString>
@@ -27,30 +28,7 @@ void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
     if (n < 16)
     {
         // The normal pre-defined typical 16 colors.
-        /// @TODO these should probably be configurable.
-        static const Qt::GlobalColor colorcodes[] = {
-            // The normal pre-defined typical 8 colors.
-            Qt::black,
-            Qt::darkRed,
-            Qt::darkGreen,
-            Qt::darkYellow,
-            Qt::darkBlue,
-            Qt::darkMagenta,
-            Qt::darkCyan,
-            Qt::lightGray,
-
-            // bold/intense? versions of the normal 8 colors.
-            Qt::gray,
-            Qt::red,
-            Qt::green,
-            Qt::yellow,
-            Qt::blue,
-            Qt::magenta,
-            Qt::cyan,
-            Qt::white
-        };
-
-        color = QColor(colorcodes[n]);
+        color = QColor(kristall::document_style.ansi_colors[n]);
     }
     else if (n < 232)
     {

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -74,28 +74,28 @@ void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
         /// @TODO these should probably be configurable.
         switch (n)
         {
-            case 0: // black
+            case 8: // black
                 bg ? setBgColor(format, 0x55, 0x55, 0x55) : setBgColor(format, 0x55, 0x55, 0x55);
                 break;
-            case 1: // red
+            case 9: // red
                 bg ? setBgColor(format, 0xFF, 0x55, 0x55) : setBgColor(format, 0xFF, 0x55, 0x55);
                 break;
-            case 2: // green
+            case 10: // green
                 bg ? setBgColor(format, 0x55, 0xFF, 0x55) : setBgColor(format, 0x55, 0xFF, 0x55);
                 break;
-            case 3: // yellow
+            case 11: // yellow
                 bg ? setBgColor(format, 0xFF, 0xFF, 0x55) : setBgColor(format, 0xFF, 0xFF, 0x55);
                 break;
-            case 4: // blue
+            case 12: // blue
                 bg ? setBgColor(format, 0x55, 0x55, 0xFF) : setBgColor(format, 0x55, 0x55, 0xFF);
                 break;
-            case 5: // magenta
+            case 13: // magenta
                 bg ? setBgColor(format, 0xFF, 0x55, 0xFF) : setBgColor(format, 0xFF, 0x55, 0xFF);
                 break;
-            case 6: // cyan
+            case 14: // cyan
                 bg ? setBgColor(format, 0x55, 0xFF, 0xFF) : setBgColor(format, 0x55, 0xFF, 0xFF);
                 break;
-            case 7: // white
+            case 15: // white
                 bg ? setBgColor(format, 0xFF, 0xFF, 0xFF) : setBgColor(format, 0xFF, 0xFF, 0xFF);
                 break;
         }

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -106,6 +106,7 @@ void parseSGR(
         enum {
             Reset = 0, Bold, Light, Italic, Underline,
             Reverse = 7,
+            StrikeOut = 9,
 
             // some implementations interpret 21 as Bold off
             DoubleUnderline = 21, NormalWeight, ItalicOff, UnderlineOff,
@@ -147,6 +148,9 @@ void parseSGR(
                     format.setBackground(fg);
                     inverted = true;
                 }
+                break;
+            case StrikeOut:
+                format.setFontStrikeOut(true);
                 break;
             case DoubleUnderline:
                 format.setUnderlineStyle(QTextCharFormat::WaveUnderline);

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -101,28 +101,44 @@ void parseSGR(
     if (args.empty()) return;
     for (auto it = args.cbegin(); it != args.cend(); ++it)
     {
+        /// @TODO A whole bunch of unimplemented SGR codes are unimplemented 
+        ///       yet (eg: blink or font switching)
+        enum {
+            Reset = 0, Bold, Light, Italic, Underline,
+            Reverse = 7,
+
+            // some implementations interpret 21 as Bold off
+            DoubleUnderline = 21, NormalWeight, ItalicOff, UnderlineOff,
+            ReverseOff = 27,
+            StrikeOutOff = 29,
+
+            // 30-37 and 40-47 color codes are handled in the default case
+            SetForeground = 38,
+            DefaultForeground = 39,
+            SetBackground = 48,
+            DefaultBackground = 49,
+        };
+
         const auto arg = *it;
         switch(arg)
         {
-            /// @TODO A whole bunch of unimplemented SGR codes are unimplemented 
-            ///       yet (eg: blink or font switching)
-            case 0: // Reset.
+            case Reset:
                 format = defaultFormat;
                 break;
-            case 1: // Bold.
+            case Bold:
                 format.setFontWeight(QFont::Bold);
                 break;
-            case 2: // Light.
+            case Light:
                 format.setFontWeight(QFont::Light);
                 break;
-            case 3: // Italic.
+            case Italic:
                 format.setFontItalic(true);
                 break;
-            case 4: // Underline.
+            case Underline:
                 /// @TODO Underline style should be configurable?
                 format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
                 break;
-            case 7: // Reverse video (invert).
+            case Reverse:
                 if (!inverted)
                 {
                     const auto fg = format.foreground();
@@ -132,19 +148,19 @@ void parseSGR(
                     inverted = true;
                 }
                 break;
-            case 21: // Double underline (or bold off?)
+            case DoubleUnderline:
                 format.setUnderlineStyle(QTextCharFormat::WaveUnderline);
                 break;
-            case 22: // Normal weight.
+            case NormalWeight:
                 format.setFontWeight(QFont::Normal);
                 break;
-            case 23: // Not italic.
+            case ItalicOff:
                 format.setFontItalic(false);
                 break;
-            case 24: // Not underlined.
+            case UnderlineOff:
                 format.setFontUnderline(QTextCharFormat::NoUnderline);
                 break;
-            case 27: // Not inverted.
+            case ReverseOff:
                 if (inverted)
                 {
                     const auto fg = format.foreground();
@@ -154,10 +170,10 @@ void parseSGR(
                     inverted = false;
                 }
                 break;
-            case 29: // Not crossed out.
+            case StrikeOutOff:
                 format.setFontStrikeOut(false);
                 break;
-            case 38: // Set foreground (RGB)
+            case SetForeground:
                 if (args.size() > 2)
                 {
                     ++it;
@@ -187,10 +203,10 @@ void parseSGR(
                     }
                 }
                 break;
-            case 39: // Default foreground color.
+            case DefaultForeground:
                 format.setForeground(defaultFormat.foreground());
                 break;
-            case 48: // Set background (RGB)
+            case SetBackground:
                 if (args.size() > 2)
                 {
                     ++it;
@@ -216,7 +232,7 @@ void parseSGR(
                     }
                 }
                 break;
-            case 49: // Default background color.
+            case DefaultBackground:
                 format.setBackground(defaultFormat.background());
                 break;
             default:

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -324,8 +324,6 @@ void parseCSI(
                 }
                 break;
             case 'm': // SGR
-                // CSI m is treated as CSI 0 m. (and thus, SGR 0 m)
-                if (numericArguments.size() == 1) numericArguments.insert(numericArguments.begin(), 0);
                 parseSGR(numericArguments, input, it, format, defaultFormat, cursor);
                 break;
             default:

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -20,85 +20,37 @@
 static constexpr const char escapeString = '\033';
 bool inverted{false};
 
-void setFgColor(QTextCharFormat& format, int r, int g, int b)
-{
-    auto col = format.foreground();
-    col.setColor(QColor(r,g,b));
-    format.setForeground(col);
-}
-
-void setBgColor(QTextCharFormat& format, int r, int g, int b)
-{
-    auto col = format.background();
-    col.setColor(QColor(r,g,b));
-    format.setBackground(col);
-}
-
 void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
 {
-    if (n < 8)
+    QColor color;
+
+    if (n < 16)
     {
-        // The normal pre-defined typical 8 colors.
+        // The normal pre-defined typical 16 colors.
         /// @TODO these should probably be configurable.
-        switch (n)
-        {
-            case 0: // black
-                bg ? setBgColor(format, 0, 0, 0) : setBgColor(format, 0, 0, 0);
-                break;
-            case 1: // red
-                bg ? setBgColor(format, 0xAA, 0, 0) : setBgColor(format, 0xAA, 0, 0);
-                break;
-            case 2: // green
-                bg ? setBgColor(format, 0, 0xAA, 0) : setBgColor(format, 0, 0xAA, 0);
-                break;
-            case 3: // yellow
-                bg ? setBgColor(format, 0xAA, 0xAA, 0) : setBgColor(format, 0xAA, 0xAA, 0);
-                break;
-            case 4: // blue
-                bg ? setBgColor(format, 0, 0, 0xAA) : setBgColor(format, 0, 0, 0xAA);
-                break;
-            case 5: // magenta
-                bg ? setBgColor(format, 0xAA, 0, 0xAA) : setBgColor(format, 0xAA, 0, 0xAA);
-                break;
-            case 6: // cyan
-                bg ? setBgColor(format, 0, 0xAA, 0xAA) : setBgColor(format, 0, 0xAA, 0xAA);
-                break;
-            case 7: // white
-                bg ? setBgColor(format, 0xAA, 0xAA, 0xAA) : setBgColor(format, 0xAA, 0xAA, 0xAA);
-                break;
-        }
-    }
-    else if (n < 16)
-    {
-        // bold/intense? versions of the normal 8 colors.
-        /// @TODO these should probably be configurable.
-        switch (n)
-        {
-            case 8: // black
-                bg ? setBgColor(format, 0x55, 0x55, 0x55) : setBgColor(format, 0x55, 0x55, 0x55);
-                break;
-            case 9: // red
-                bg ? setBgColor(format, 0xFF, 0x55, 0x55) : setBgColor(format, 0xFF, 0x55, 0x55);
-                break;
-            case 10: // green
-                bg ? setBgColor(format, 0x55, 0xFF, 0x55) : setBgColor(format, 0x55, 0xFF, 0x55);
-                break;
-            case 11: // yellow
-                bg ? setBgColor(format, 0xFF, 0xFF, 0x55) : setBgColor(format, 0xFF, 0xFF, 0x55);
-                break;
-            case 12: // blue
-                bg ? setBgColor(format, 0x55, 0x55, 0xFF) : setBgColor(format, 0x55, 0x55, 0xFF);
-                break;
-            case 13: // magenta
-                bg ? setBgColor(format, 0xFF, 0x55, 0xFF) : setBgColor(format, 0xFF, 0x55, 0xFF);
-                break;
-            case 14: // cyan
-                bg ? setBgColor(format, 0x55, 0xFF, 0xFF) : setBgColor(format, 0x55, 0xFF, 0xFF);
-                break;
-            case 15: // white
-                bg ? setBgColor(format, 0xFF, 0xFF, 0xFF) : setBgColor(format, 0xFF, 0xFF, 0xFF);
-                break;
-        }
+        static const Qt::GlobalColor colorcodes[] = {
+            // The normal pre-defined typical 8 colors.
+            Qt::black,
+            Qt::darkRed,
+            Qt::darkGreen,
+            Qt::darkYellow,
+            Qt::darkBlue,
+            Qt::darkMagenta,
+            Qt::darkCyan,
+            Qt::lightGray,
+
+            // bold/intense? versions of the normal 8 colors.
+            Qt::gray,
+            Qt::red,
+            Qt::green,
+            Qt::yellow,
+            Qt::blue,
+            Qt::magenta,
+            Qt::cyan,
+            Qt::white
+        };
+
+        color = QColor(colorcodes[n]);
     }
     else if (n < 232)
     {
@@ -110,14 +62,19 @@ void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
         unsigned int index_B = ((n - 16) % 6);
         unsigned char b = index_B > 0 ? 55 + index_B * 40 : 0;
 
-        bg ? setBgColor(format, r, g, b) : setFgColor(format, r, g, b);
+        color = QColor(r, g, b);
     }
     else
     {
         // grayscale pallete.
         unsigned char g = (n - 232) * 10 + 8;
-        bg ? setBgColor(format, g, g, g) : setFgColor(format, g, g, g);
+        color = QColor(g, g, g);
     }
+
+    if (bg)
+        format.setBackground(color);
+    else
+        format.setForeground(color);
 }
 
 QString parseNumber(const QString& input, QString::const_iterator& it)
@@ -225,7 +182,7 @@ void parseSGR(
                             const auto green = *it;
                             ++it;
                             const auto blue = *it;
-                            setFgColor(format, red, green, blue);
+                            format.setForeground(QColor(red, green, blue));
                         }
                     }
                 }
@@ -254,7 +211,7 @@ void parseSGR(
                             const auto green = *it;
                             ++it;
                             const auto blue = *it;
-                            setBgColor(format, red, green, blue);
+                            format.setBackground(QColor(red, green, blue));
                         }
                     }
                 }

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -120,10 +120,10 @@ void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
     }
 }
 
-QString parseNumber(const QString& input, QString::iterator& it)
+QString parseNumber(const QString& input, QString::const_iterator& it)
 {
     QString result;
-    while (it != input.end())
+    while (it != input.cend())
     {
         const auto currentCharacter = *it;
         if (!currentCharacter.isNumber()) break;
@@ -136,13 +136,13 @@ QString parseNumber(const QString& input, QString::iterator& it)
 void parseSGR(
     std::vector<unsigned char>& args,
     const QString& input,
-    QString::iterator& it,
+    QString::const_iterator& it,
     QTextCharFormat& format,
     const QTextCharFormat& defaultFormat,
     QTextCursor& cursor)
 {
     if (args.empty()) return;
-    for (auto it = args.begin(); it != args.end(); ++it)
+    for (auto it = args.cbegin(); it != args.cend(); ++it)
     {
         const auto arg = *it;
         switch(arg)
@@ -266,7 +266,7 @@ void parseSGR(
     }
 }
 
-std::vector<unsigned char> parseNumericArguments(const QString& input, QString::iterator& it)
+std::vector<unsigned char> parseNumericArguments(const QString& input, QString::const_iterator& it)
 {
     std::vector<unsigned char> result;
     while (it != input.end())
@@ -292,14 +292,14 @@ std::vector<unsigned char> parseNumericArguments(const QString& input, QString::
 
 void parseCSI(
     const QString& input,
-    QString::iterator& it,
+    QString::const_iterator& it,
     QTextCharFormat& format,
     const QTextCharFormat& defaultFormat,
     QTextCursor& cursor)
 {
     std::vector<unsigned char> numericArguments = parseNumericArguments(input, it);
     char numericArgument = numericArguments.empty() ? 1 : numericArguments[0];
-    if (it != input.end())
+    if (it != input.cend())
     {
         const auto code = (*it).unicode();
         switch(code)
@@ -374,7 +374,7 @@ void RenderEscapeCodes(const QByteArray &input, const QTextCharFormat& format, Q
     auto textFormat = format;
     const auto tokens = input.split(escapeString);
     const auto inputString = QString::fromUtf8(input);
-    for (QString::iterator it = const_cast<QString::iterator>(inputString.begin()); it != inputString.end(); ++it)
+    for (QString::const_iterator it = inputString.cbegin(); it != inputString.cend(); ++it)
     {
         const auto currentCharacter = *it;;
         if (currentCharacter == escapeString)

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -219,6 +219,18 @@ void parseSGR(
             case 49: // Default background color.
                 format.setBackground(defaultFormat.background());
                 break;
+            default:
+                // foreground, background and their bright equivalents
+                if (arg >= 30 && arg < 38)
+                    setColor(format, arg - 30);
+                else if (arg >= 40 && arg < 48)
+                    setColor(format, arg - 40, true);
+                else if (arg >= 90 && arg < 98)
+                    setColor(format, arg - 90 + 8);
+                else if (arg >= 100 && arg < 108)
+                    setColor(format, arg - 100 + 8, true);
+
+                break;
         }
     }
 }


### PR DESCRIPTION
The only way to set a custom color palette for now is to edit it directly in the config files. I think we shouldn't put them in the settings dialog just yet, as I think it would make settings a bit harder to navigate.