### PR TITLE
Small search improvements

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -106,12 +106,16 @@ BrowserTab::BrowserTab(MainWindow *mainWindow) : QWidget(nullptr),
         connect(sc, &QShortcut::activated, this, &BrowserTab::on_refresh_button_clicked);
     }
     {
-        QShortcut * sc = new QShortcut(QKeySequence("F3"), this);
-        connect(sc, &QShortcut::activated, this, &BrowserTab::on_search_next_clicked);
+        QShortcut * sc0 = new QShortcut(QKeySequence("Return"), this),
+            *sc1 = new QShortcut(QKeySequence("F3"), this);
+        connect(sc0, &QShortcut::activated, this, &BrowserTab::on_search_next_clicked);
+        connect(sc1, &QShortcut::activated, this, &BrowserTab::on_search_next_clicked);
     }
     {
-        QShortcut * sc = new QShortcut(QKeySequence("Shift+F3"), this);
-        connect(sc, &QShortcut::activated, this, &BrowserTab::on_search_previous_clicked);
+        QShortcut * sc0 = new QShortcut(QKeySequence("Shift+Return"), this),
+            *sc1 = new QShortcut(QKeySequence("Shift+F3"), this);
+        connect(sc0, &QShortcut::activated, this, &BrowserTab::on_search_previous_clicked);
+        connect(sc1, &QShortcut::activated, this, &BrowserTab::on_search_previous_clicked);
     }
     {
         QShortcut * sc = new QShortcut(QKeySequence("Escape"), this->ui->search_bar);

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1628,7 +1628,8 @@ void BrowserTab::on_search_box_returnPressed()
 
 void BrowserTab::on_search_next_clicked()
 {
-    if (!this->ui->text_browser->find(this->ui->search_box->text()))
+    if (!this->ui->text_browser->find(this->ui->search_box->text()) &&
+        this->current_buffer.contains(this->ui->search_box->text().toUtf8()))
     {
         // Wrap search
         this->ui->text_browser->moveCursor(QTextCursor::Start);
@@ -1638,7 +1639,8 @@ void BrowserTab::on_search_next_clicked()
 
 void BrowserTab::on_search_previous_clicked()
 {
-    if (!this->ui->text_browser->find(this->ui->search_box->text(), QTextDocument::FindBackward))
+    if (!this->ui->text_browser->find(this->ui->search_box->text(), QTextDocument::FindBackward) &&
+        this->current_buffer.contains(this->ui->search_box->text().toUtf8()))
     {
         // Wrap search
         this->ui->text_browser->moveCursor(QTextCursor::End);

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -22,6 +22,7 @@
 #include "ioutil.hpp"
 #include "kristall.hpp"
 #include "widgets/favouritepopup.hpp"
+#include "widgets/searchbox.hpp"
 
 #include <cassert>
 #include <QTabWidget>
@@ -106,16 +107,8 @@ BrowserTab::BrowserTab(MainWindow *mainWindow) : QWidget(nullptr),
         connect(sc, &QShortcut::activated, this, &BrowserTab::on_refresh_button_clicked);
     }
     {
-        QShortcut * sc0 = new QShortcut(QKeySequence("Return"), this),
-            *sc1 = new QShortcut(QKeySequence("F3"), this);
-        connect(sc0, &QShortcut::activated, this, &BrowserTab::on_search_next_clicked);
-        connect(sc1, &QShortcut::activated, this, &BrowserTab::on_search_next_clicked);
-    }
-    {
-        QShortcut * sc0 = new QShortcut(QKeySequence("Shift+Return"), this),
-            *sc1 = new QShortcut(QKeySequence("Shift+F3"), this);
-        connect(sc0, &QShortcut::activated, this, &BrowserTab::on_search_previous_clicked);
-        connect(sc1, &QShortcut::activated, this, &BrowserTab::on_search_previous_clicked);
+        connect(this->ui->search_box, &SearchBox::searchNext, this, &BrowserTab::on_search_next_clicked);
+        connect(this->ui->search_box, &SearchBox::searchPrev, this, &BrowserTab::on_search_previous_clicked);
     }
     {
         QShortcut * sc = new QShortcut(QKeySequence("Escape"), this->ui->search_bar);
@@ -1635,12 +1628,22 @@ void BrowserTab::on_search_box_returnPressed()
 
 void BrowserTab::on_search_next_clicked()
 {
-    this->ui->text_browser->find(this->ui->search_box->text());
+    if (!this->ui->text_browser->find(this->ui->search_box->text()))
+    {
+        // Wrap search
+        this->ui->text_browser->moveCursor(QTextCursor::Start);
+        this->ui->text_browser->find(this->ui->search_box->text());
+    }
 }
 
 void BrowserTab::on_search_previous_clicked()
 {
-    this->ui->text_browser->find(this->ui->search_box->text(), QTextDocument::FindBackward);
+    if (!this->ui->text_browser->find(this->ui->search_box->text(), QTextDocument::FindBackward))
+    {
+        // Wrap search
+        this->ui->text_browser->moveCursor(QTextCursor::End);
+        this->ui->text_browser->find(this->ui->search_box->text(), QTextDocument::FindBackward);
+    }
 }
 
 void BrowserTab::on_close_search_clicked()

--- a/src/browsertab.ui
+++ b/src/browsertab.ui
@@ -227,7 +227,7 @@ p, li { white-space: pre-wrap; }
        <number>0</number>
       </property>
       <item>
-       <widget class="QLineEdit" name="search_box"/>
+       <widget class="SearchBox" name="search_box"/>
       </item>
       <item>
        <widget class="QToolButton" name="search_previous">
@@ -296,6 +296,11 @@ p, li { white-space: pre-wrap; }
    <class>FavouriteButton</class>
    <extends>QToolButton</extends>
    <header>widgets/favouritebutton.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>SearchBox</class>
+   <extends>QLineEdit</extends>
+   <header>widgets/searchbox.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -121,7 +121,8 @@ SOURCES += \
     widgets/ssltrusteditor.cpp \
     widgets/favouritepopup.cpp \
     widgets/favouritebutton.cpp \
-    cachehandler.cpp
+    cachehandler.cpp \
+    widgets/searchbox.cpp
 
 HEADERS += \
     ../lib/luis-l-gist/interactiveview.hpp \
@@ -167,7 +168,8 @@ HEADERS += \
     widgets/ssltrusteditor.hpp \
     widgets/favouritepopup.hpp \
     widgets/favouritebutton.hpp \
-    cachehandler.hpp
+    cachehandler.hpp \
+    widgets/searchbox.hpp
 
 FORMS += \
   browsertab.ui \

--- a/src/widgets/searchbox.cpp
+++ b/src/widgets/searchbox.cpp
@@ -1,0 +1,31 @@
+#include "searchbox.hpp"
+
+#include <QKeyEvent>
+#include <QDebug>
+
+SearchBox::SearchBox(QWidget * parent) : QLineEdit(parent)
+{}
+
+void SearchBox::keyPressEvent(QKeyEvent *event)
+{
+    if(event->key() == Qt::Key_Return || event->key() == Qt::Key_F3) {
+        if (event->modifiers() == Qt::ShiftModifier) {
+            emit searchPrev();
+        }
+        else {
+            emit searchNext();
+        }
+    } else {
+        QLineEdit::keyPressEvent(event);
+    }
+}
+
+void SearchBox::keyReleaseEvent(QKeyEvent *event)
+{
+    if(event->key() == Qt::Key_Return) {
+        // Eat the event
+    } else {
+        QLineEdit::keyReleaseEvent(event);
+    }
+}
+

--- a/src/widgets/searchbox.hpp
+++ b/src/widgets/searchbox.hpp
@@ -1,0 +1,20 @@
+#ifndef SEARCHBOX_HPP
+#define SEARCHBOX_HPP
+
+#include <QLineEdit>
+
+class SearchBox : public QLineEdit
+{
+    Q_OBJECT
+public:
+    explicit SearchBox(QWidget *parent = nullptr);
+
+signals:
+    void searchNext();
+    void searchPrev();
+public:
+    void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
+};
+
+#endif // SEARCHBOX_HPP


### PR DESCRIPTION
Closes #144

* Return key now moves to next search item
* Shift+Return moves to previous search item
* Searches are wrapped

Had to do this in a new subclass, SearchBox, as setting a QShortcut with Return as the key sequence would cause Return-key usage to be broken elsewhere (e.g in the URL bar). The subclass handles key press events and emits a signal when return/shift+return is pressed.