### PR TITLE
New gemtext formatting options and improvements

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -107,7 +107,20 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
 
     this->ui->auto_theme->setCurrentIndex(this->current_style.theme);
 
+    this->ui->link_local_prefix->setText(this->current_style.internal_link_prefix);
+    this->ui->link_foreign_prefix->setText(this->current_style.external_link_prefix);
+
     this->ui->page_margin->setValue(this->current_style.margin);
+
+    this->ui->enable_justify_text->setChecked(this->current_style.justify_text);
+
+    this->ui->line_height_p->setValue(this->current_style.line_height_p);
+    this->ui->line_height_h->setValue(this->current_style.line_height_h);
+
+    this->ui->indent_bq->setValue(this->current_style.indent_bq);
+    this->ui->indent_p->setValue(this->current_style.indent_p);
+    this->ui->indent_h->setValue(this->current_style.indent_h);
+    this->ui->indent_l->setValue(this->current_style.indent_l);
 
     auto setFontAndColor = [this](QLabel * label, const QFont &font, QColor color)
     {
@@ -419,6 +432,49 @@ void SettingsDialog::on_page_margin_valueChanged(double value)
     this->current_style.margin = value;
     this->reloadStylePreview();
 }
+
+void SettingsDialog::on_enable_justify_text_clicked(bool checked)
+{
+    this->current_style.justify_text = checked;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_line_height_p_valueChanged(double value)
+{
+    this->current_style.line_height_p = value;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_line_height_h_valueChanged(double value)
+{
+    this->current_style.line_height_h = value;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_indent_bq_valueChanged(int value)
+{
+    this->current_style.indent_bq = value;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_indent_h_valueChanged(int value)
+{
+    this->current_style.indent_h = value;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_indent_p_valueChanged(int value)
+{
+    this->current_style.indent_p = value;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_indent_l_valueChanged(int value)
+{
+    this->current_style.indent_l = value;
+    this->reloadStylePreview();
+}
+
 
 void SettingsDialog::on_presets_currentIndexChanged(int index)
 {

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -78,6 +78,17 @@ private slots:
 
     void on_page_margin_valueChanged(double arg1);
 
+    void on_enable_justify_text_clicked(bool arg1);
+
+    void on_line_height_p_valueChanged(double arg1);
+
+    void on_line_height_h_valueChanged(double arg1);
+
+    void on_indent_bq_valueChanged(int value);
+    void on_indent_p_valueChanged(int value);
+    void on_indent_h_valueChanged(int value);
+    void on_indent_l_valueChanged(int value);
+
     void on_presets_currentIndexChanged(int index);
 
     void on_preset_new_clicked();

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>850</width>
+    <width>1100</width>
     <height>650</height>
    </rect>
   </property>
@@ -877,7 +877,166 @@
            </property>
           </widget>
          </item>
+         <item row="14" column="0">
+          <widget class="QLabel" name="label_25">
+           <property name="text">
+            <string>Other options</string>
+           </property>
+          </widget>
+         </item>
          <item row="14" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_98">
+           <item>
+            <widget class="QCheckBox" name="enable_justify_text">
+             <property name="text">
+              <string>Justify text</string>
+             </property>
+             <property name="toolTip">
+              <string>Justify text on the page, instead of left-aligning it.</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="15" column="0">
+          <widget class="QLabel" name="label_35">
+           <property name="text">
+            <string>Line height (paragraph)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="15" column="1">
+          <widget class="QDoubleSpinBox" name="line_height_p">
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <double>30</double>
+           </property>
+          </widget>
+         </item>
+         <item row="16" column="0">
+          <widget class="QLabel" name="label_36">
+           <property name="text">
+            <string>Line height (header)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="16" column="1">
+          <widget class="QDoubleSpinBox" name="line_height_h">
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <double>30</double>
+           </property>
+          </widget>
+         </item>
+
+         <item row="17" column="0">
+          <widget class="QLabel" name="label_37">
+           <property name="text">
+            <string>Indentation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="17" column="1">
+          <layout class="QHBoxLayout" name="indent_container">
+
+           <item>
+            <widget class="QLabel" name="label_96">
+             <property name="text">
+              <string>Par:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="indent_p">
+             <property name="value">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>7</number>
+             </property>
+            </widget>
+           </item>
+
+           <item>
+            <widget class="QLabel" name="label_94">
+             <property name="text">
+              <string>Hea:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="indent_h">
+             <property name="value">
+              <number>0</number>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>7</number>
+             </property>
+            </widget>
+           </item>
+
+           <item>
+            <widget class="QLabel" name="label_95">
+             <property name="text">
+              <string>Quo:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="indent_bq">
+             <property name="value">
+              <number>2</number>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>7</number>
+             </property>
+            </widget>
+           </item>
+
+           <item>
+            <widget class="QLabel" name="label_93">
+             <property name="text">
+              <string>Lst:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="indent_l">
+             <property name="value">
+              <number>2</number>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>7</number>
+             </property>
+            </widget>
+           </item>
+
+          </layout>
+         </item>
+
+         <item row="18" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QComboBox" name="presets"/>
@@ -953,7 +1112,7 @@
            </item>
           </layout>
          </item>
-         <item row="14" column="0">
+         <item row="18" column="0">
           <widget class="QLabel" name="label_17">
            <property name="text">
             <string>Presets</string>
@@ -1106,6 +1265,13 @@
   <tabstop>quote_change_color</tabstop>
   <tabstop>auto_theme</tabstop>
   <tabstop>page_margin</tabstop>
+  <tabstop>enable_justify_text</tabstop>
+  <tabstop>line_height_p</tabstop>
+  <tabstop>line_height_h</tabstop>
+  <tabstop>indent_p</tabstop>
+  <tabstop>indent_h</tabstop>
+  <tabstop>indent_bq</tabstop>
+  <tabstop>indent_l</tabstop>
   <tabstop>presets</tabstop>
   <tabstop>preset_new</tabstop>
   <tabstop>preset_save</tabstop>

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -138,7 +138,11 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     ansi_colors({"black", "darkred", "darkgreen", "darkgoldenrod",
         "darkblue", "darkmagenta", "darkcyan", "lightgray",
         "gray", "red", "green", "goldenrod",
-        "lightblue", "magenta", "cyan", "white"})
+        "lightblue", "magenta", "cyan", "white"}),
+    justify_text(true),
+    line_height_p(5.0),
+    line_height_h(0.0),
+    indent_bq(2), indent_p(1), indent_h(0), indent_l(2)
 {
     if (do_init) this->initialiseDefaultFonts();
 }
@@ -265,6 +269,19 @@ bool DocumentStyle::save(QSettings &settings) const
 
         settings.endGroup();
     }
+    {
+        settings.beginGroup("Formatting");
+
+        settings.setValue("justify_text", justify_text);
+        settings.setValue("line_height_p", line_height_p);
+        settings.setValue("line_height_h", line_height_h);
+        settings.setValue("indent_bq", indent_bq);
+        settings.setValue("indent_p", indent_p);
+        settings.setValue("indent_h", indent_h);
+        settings.setValue("indent_l", indent_l);
+
+        settings.endGroup();
+    }
 
     return true;
 }
@@ -354,6 +371,19 @@ bool DocumentStyle::load(QSettings &settings)
 
             internal_link_prefix = settings.value("internal_prefix", internal_link_prefix).toString();
             external_link_prefix = settings.value("external_prefix", external_link_prefix).toString();
+
+            settings.endGroup();
+        }
+        {
+            settings.beginGroup("Formatting");
+
+            justify_text = settings.value("justify_text", justify_text).toBool();
+            line_height_p = settings.value("line_height_p", line_height_p).toDouble();
+            line_height_h = settings.value("line_height_h", line_height_h).toDouble();
+            indent_bq = settings.value("indent_bq", indent_bq).toInt();
+            indent_p = settings.value("indent_p", indent_p).toInt();
+            indent_h = settings.value("indent_h", indent_h).toInt();
+            indent_l = settings.value("indent_l", indent_l).toInt();
 
             settings.endGroup();
         }

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -53,6 +53,11 @@ struct DocumentStyle
 
     QStringList ansi_colors;
 
+    bool justify_text;
+    double line_height_p;
+    double line_height_h;
+    int indent_bq, indent_p, indent_h, indent_l;
+
     bool save(QSettings & settings) const;
     bool load(QSettings & settings);
 

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -77,9 +77,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
             {
                 if (current_list == nullptr)
                 {
-                    cursor.setBlockFormat(text_style.list_format);
                     cursor.deletePreviousChar();
-                    current_list = cursor.insertList(QTextListFormat::ListDisc);
+                    current_list = cursor.insertList(text_style.list_format);
                 }
                 else
                 {

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -77,6 +77,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
             {
                 if (current_list == nullptr)
                 {
+                    cursor.setBlockFormat(text_style.list_format);
                     cursor.deletePreviousChar();
                     current_list = cursor.insertList(QTextListFormat::ListDisc);
                 }
@@ -129,7 +130,9 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
                 fmt.setAnchor(true);
                 fmt.setAnchorNames(QStringList { id });
 
-                cursor.insertText(heading + "\n", fmt);
+                cursor.setBlockFormat(text_style.heading_format);
+                cursor.insertText(heading, fmt);
+                cursor.insertText("\n", text_style.standard);
                 outline.appendH3(heading, id);
             }
             else if (line.startsWith("##"))
@@ -141,7 +144,9 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
                 fmt.setAnchor(true);
                 fmt.setAnchorNames(QStringList { id });
 
-                cursor.insertText(heading + "\n", fmt);
+                cursor.setBlockFormat(text_style.heading_format);
+                cursor.insertText(heading, fmt);
+                cursor.insertText("\n", text_style.standard);
                 outline.appendH2(heading, id);
             }
             else if (line.startsWith("#"))
@@ -153,7 +158,9 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
                 fmt.setAnchor(true);
                 fmt.setAnchorNames(QStringList { id });
 
-                cursor.insertText(heading + "\n", fmt);
+                cursor.setBlockFormat(text_style.heading_format);
+                cursor.insertText(heading, fmt);
+                cursor.insertText("\n", text_style.standard);
                 outline.appendH1(heading, id);
 
                 // Use first heading as the page's title.
@@ -220,6 +227,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
                 fmt.setAnchor(true);
                 fmt.setAnchorHref(absolute_url.toString());
+                cursor.setBlockFormat(text_style.link_format);
                 cursor.insertText(prefix + title + suffix + "\n", fmt);
             }
             else if (line.startsWith("```"))
@@ -228,6 +236,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
             }
             else
             {
+                cursor.setBlockFormat(text_style.standard_format);
+
                 if(emit_fancy_text)
                 {
                     // TODO: Fix UTF-8 encoding here… Don't emit single characters but always spans!

--- a/src/renderers/textstyleinstance.cpp
+++ b/src/renderers/textstyleinstance.cpp
@@ -28,6 +28,24 @@ TextStyleInstance::TextStyleInstance(DocumentStyle const & themed_style)
 
   preformatted_format.setNonBreakableLines(true);
 
-  block_quote_format.setIndent(1);
+  block_quote_format.setIndent(2);
   block_quote_format.setBackground(themed_style.blockquote_color);
+
+  // Other alignments
+  standard_format.setAlignment(Qt::AlignJustify);
+  standard_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
+  standard_format.setIndent(1);
+
+  link_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
+
+  block_quote_format.setAlignment(Qt::AlignJustify);
+  block_quote_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
+
+  list_format.setAlignment(Qt::AlignJustify);
+  list_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
+  list_format.setIndent(2);
+
+  preformatted_format.setIndent(1);
+
+  heading_format.setLineHeight(0, QTextBlockFormat::LineDistanceHeight);
 }

--- a/src/renderers/textstyleinstance.cpp
+++ b/src/renderers/textstyleinstance.cpp
@@ -28,24 +28,30 @@ TextStyleInstance::TextStyleInstance(DocumentStyle const & themed_style)
 
   preformatted_format.setNonBreakableLines(true);
 
-  block_quote_format.setIndent(2);
+  block_quote_format.setIndent(themed_style.indent_bq);
   block_quote_format.setBackground(themed_style.blockquote_color);
 
   // Other alignments
-  standard_format.setAlignment(Qt::AlignJustify);
-  standard_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
-  standard_format.setIndent(1);
+  auto align = themed_style.justify_text ? Qt::AlignJustify : Qt::AlignLeft;
 
-  link_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
+  standard_format.setAlignment(align);
+  standard_format.setLineHeight(themed_style.line_height_p,
+    QTextBlockFormat::LineDistanceHeight);
+  standard_format.setIndent(themed_style.indent_p);
 
-  block_quote_format.setAlignment(Qt::AlignJustify);
-  block_quote_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
+  link_format.setLineHeight(themed_style.line_height_p,
+    QTextBlockFormat::LineDistanceHeight);
 
-  list_format.setAlignment(Qt::AlignJustify);
-  list_format.setLineHeight(5, QTextBlockFormat::LineDistanceHeight);
-  list_format.setIndent(2);
+  block_quote_format.setAlignment(align);
+  block_quote_format.setLineHeight(themed_style.line_height_p,
+    QTextBlockFormat::LineDistanceHeight);
 
-  preformatted_format.setIndent(1);
+  list_format.setStyle(QTextListFormat::ListDisc);
+  list_format.setIndent(themed_style.indent_l);
 
-  heading_format.setLineHeight(0, QTextBlockFormat::LineDistanceHeight);
+  preformatted_format.setIndent(themed_style.indent_p);
+
+  heading_format.setLineHeight(themed_style.line_height_h,
+    QTextBlockFormat::LineDistanceHeight);
+  heading_format.setIndent(themed_style.indent_h);
 }

--- a/src/renderers/textstyleinstance.hpp
+++ b/src/renderers/textstyleinstance.hpp
@@ -22,7 +22,7 @@ struct TextStyleInstance
     QTextBlockFormat block_quote_format;
     QTextBlockFormat heading_format;
     QTextBlockFormat link_format;
-    QTextBlockFormat list_format;
+    QTextListFormat list_format;
 
     explicit TextStyleInstance(DocumentStyle const & style);
 };

--- a/src/renderers/textstyleinstance.hpp
+++ b/src/renderers/textstyleinstance.hpp
@@ -20,6 +20,9 @@ struct TextStyleInstance
     QTextBlockFormat standard_format;
     QTextBlockFormat preformatted_format;
     QTextBlockFormat block_quote_format;
+    QTextBlockFormat heading_format;
+    QTextBlockFormat link_format;
+    QTextBlockFormat list_format;
 
     explicit TextStyleInstance(DocumentStyle const & style);
 };


### PR DESCRIPTION
This PR makes various changes to help enhance readability of gemtext pages. These changes can be configured through the preferences via new settings added to the Style tab

* Text is now justified by default. Can be toggled
* Line height/spacing is now adjustable for headings and general text.
* Paragraphs, headings, block quotes, and lists now have controllable indent levels. The default configuration indents paragraphs a little bit, and lists a little further. The headings are closest to the left. 

Example page with default values of new options:
![image](https://user-images.githubusercontent.com/42143005/107482551-f2295a80-6bd3-11eb-90fb-3cc47a4319fe.png)