### PR TITLE
Add page text width option, and split margins

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -6,6 +6,7 @@
 #include "renderers/geminirenderer.hpp"
 #include "renderers/plaintextrenderer.hpp"
 #include "renderers/markdownrenderer.hpp"
+#include "renderers/renderhelpers.hpp"
 
 #include "mimeparser.hpp"
 
@@ -575,7 +576,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
 
         document->setDefaultFont(doc_style.standard_font);
         document->setDefaultStyleSheet(doc_style.toStyleSheet());
-        document->setDocumentMargin(doc_style.margin);
+        renderhelpers::setPageMargins(document.get(), doc_style.margin_h, doc_style.margin_v);
 
         // Strip inline styles from page, so they don't
         // conflict with user styles.
@@ -1322,7 +1323,7 @@ void BrowserTab::updatePageMargins()
     QTextFrame *root = this->current_document->rootFrame();
     QTextFrameFormat fmt = root->frameFormat();
     int margin = std::max((this->width() - this->current_style.text_width) / 2,
-        this->current_style.margin);
+        this->current_style.margin_h);
     fmt.setLeftMargin(margin);
     fmt.setRightMargin(margin);
     root->setFrameFormat(fmt);

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -730,6 +730,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
 
     this->ui->text_browser->setDocument(document.get());
     this->current_document = std::move(document);
+    this->updatePageMargins();
 
     this->needs_rerender = false;
 
@@ -1312,6 +1313,20 @@ void BrowserTab::setUiDensity(UIDensity density)
     }
 }
 
+void BrowserTab::updatePageMargins()
+{
+    if (!this->current_document) return;
+
+    QTextFrame *root = this->current_document->rootFrame();
+    QTextFrameFormat fmt = root->frameFormat();
+    int margin = std::max((this->width() - 900) / 2, 30);
+    fmt.setLeftMargin(margin);
+    fmt.setRightMargin(margin);
+    root->setFrameFormat(fmt);
+
+    this->ui->text_browser->setDocument(this->current_document.get());
+}
+
 bool BrowserTab::trySetClientCertificate(const QString &query)
 {
     CertificateSelectionDialog dialog{this};
@@ -1651,4 +1666,10 @@ void BrowserTab::on_search_previous_clicked()
 void BrowserTab::on_close_search_clicked()
 {
     this->ui->search_bar->setVisible(false);
+}
+
+void BrowserTab::resizeEvent(QResizeEvent * event)
+{
+    this->updatePageMargins();
+    QWidget::resizeEvent(event);
 }

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -730,6 +730,7 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
 
     this->ui->text_browser->setDocument(document.get());
     this->current_document = std::move(document);
+    this->current_style = std::move(doc_style);
     this->updatePageMargins();
 
     this->needs_rerender = false;
@@ -1315,11 +1316,13 @@ void BrowserTab::setUiDensity(UIDensity density)
 
 void BrowserTab::updatePageMargins()
 {
-    if (!this->current_document) return;
+    if (!this->current_document || !this->current_style.text_width_enabled)
+        return;
 
     QTextFrame *root = this->current_document->rootFrame();
     QTextFrameFormat fmt = root->frameFormat();
-    int margin = std::max((this->width() - 900) / 2, 30);
+    int margin = std::max((this->width() - this->current_style.text_width) / 2,
+        this->current_style.margin);
     fmt.setLeftMargin(margin);
     fmt.setRightMargin(margin);
     root->setFrameFormat(fmt);

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -101,6 +101,8 @@ public:
 
     void setUiDensity(UIDensity density);
 
+    void updatePageMargins();
+
 signals:
     void titleChanged(QString const & title);
     void locationChanged(QUrl const & url);
@@ -186,6 +188,10 @@ private:
 
     bool enableClientCertificate(CryptoIdentity const & ident);
     void disableClientCertificate();
+
+protected:
+    void resizeEvent(QResizeEvent * event);
+
 public:
 
     Ui::BrowserTab *ui;

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -237,6 +237,8 @@ public:
     bool was_read_from_cache = false;
 
     RequestState request_state;
+
+    DocumentStyle current_style;
 };
 
 #endif // BROWSERTAB_HPP

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -110,7 +110,8 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
     this->ui->link_local_prefix->setText(this->current_style.internal_link_prefix);
     this->ui->link_foreign_prefix->setText(this->current_style.external_link_prefix);
 
-    this->ui->page_margin->setValue(this->current_style.margin);
+    this->ui->page_margin_h->setValue(this->current_style.margin_h);
+    this->ui->page_margin_v->setValue(this->current_style.margin_v);
 
     this->ui->enable_justify_text->setChecked(this->current_style.justify_text);
 
@@ -431,9 +432,15 @@ void SettingsDialog::on_preview_url_textChanged(const QString &)
     this->reloadStylePreview();
 }
 
-void SettingsDialog::on_page_margin_valueChanged(double value)
+void SettingsDialog::on_page_margin_h_valueChanged(double value)
 {
-    this->current_style.margin = value;
+    this->current_style.margin_h = value;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_page_margin_v_valueChanged(double value)
+{
+    this->current_style.margin_v = value;
     this->reloadStylePreview();
 }
 

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -114,6 +114,10 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
 
     this->ui->enable_justify_text->setChecked(this->current_style.justify_text);
 
+    this->ui->enable_text_width->setChecked(this->current_style.text_width_enabled);
+
+    this->ui->text_width->setValue(this->current_style.text_width);
+
     this->ui->line_height_p->setValue(this->current_style.line_height_p);
     this->ui->line_height_h->setValue(this->current_style.line_height_h);
 
@@ -437,6 +441,17 @@ void SettingsDialog::on_enable_justify_text_clicked(bool checked)
 {
     this->current_style.justify_text = checked;
     this->reloadStylePreview();
+}
+
+void SettingsDialog::on_enable_text_width_clicked(bool checked)
+{
+    this->current_style.text_width_enabled = checked;
+    this->ui->text_width->setEnabled(checked);
+}
+
+void SettingsDialog::on_text_width_valueChanged(int value)
+{
+    this->current_style.text_width = value;
 }
 
 void SettingsDialog::on_line_height_p_valueChanged(double value)

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -80,6 +80,10 @@ private slots:
 
     void on_enable_justify_text_clicked(bool arg1);
 
+    void on_enable_text_width_clicked(bool arg1);
+
+    void on_text_width_valueChanged(int value);
+
     void on_line_height_p_valueChanged(double arg1);
 
     void on_line_height_h_valueChanged(double arg1);

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -76,7 +76,8 @@ private slots:
 
     void on_preview_url_textChanged(const QString &arg1);
 
-    void on_page_margin_valueChanged(double arg1);
+    void on_page_margin_h_valueChanged(double arg1);
+    void on_page_margin_v_valueChanged(double arg1);
 
     void on_enable_justify_text_clicked(bool arg1);
 

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -857,15 +857,16 @@
          <item row="12" column="1">
           <widget class="QComboBox" name="auto_theme"/>
          </item>
+
          <item row="13" column="0">
           <widget class="QLabel" name="label_13">
            <property name="text">
-            <string>Page Margin</string>
+            <string>Left/right Page Margin</string>
            </property>
           </widget>
          </item>
          <item row="13" column="1">
-          <widget class="QDoubleSpinBox" name="page_margin">
+          <widget class="QDoubleSpinBox" name="page_margin_h">
            <property name="suffix">
             <string> px</string>
            </property>
@@ -873,18 +874,40 @@
             <number>0</number>
            </property>
            <property name="maximum">
-            <double>350.000000000000000</double>
+            <double>350</double>
            </property>
           </widget>
          </item>
+
          <item row="14" column="0">
+          <widget class="QLabel" name="label_32">
+           <property name="text">
+            <string>Top/bottom Page Margin</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="1">
+          <widget class="QDoubleSpinBox" name="page_margin_v">
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <double>350</double>
+           </property>
+          </widget>
+         </item>
+
+         <item row="15" column="0">
           <widget class="QLabel" name="label_25">
            <property name="text">
             <string>Other options</string>
            </property>
           </widget>
          </item>
-         <item row="14" column="1">
+         <item row="15" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_98">
            <item>
             <widget class="QCheckBox" name="enable_justify_text">
@@ -909,7 +932,7 @@
           </layout>
          </item>
 
-         <item row="15" column="0">
+         <item row="16" column="0">
           <widget class="QLabel" name="label_38">
            <property name="text">
             <string>Text width limit</string>
@@ -919,7 +942,7 @@
            </property>
           </widget>
          </item>
-         <item row="15" column="1">
+         <item row="16" column="1">
           <widget class="QSpinBox" name="text_width">
            <property name="minimum">
             <number>300</number>
@@ -936,14 +959,14 @@
           </widget>
          </item>
 
-         <item row="16" column="0">
+         <item row="17" column="0">
           <widget class="QLabel" name="label_35">
            <property name="text">
             <string>Line height (paragraph)</string>
            </property>
           </widget>
          </item>
-         <item row="16" column="1">
+         <item row="17" column="1">
           <widget class="QDoubleSpinBox" name="line_height_p">
            <property name="suffix">
             <string> px</string>
@@ -957,14 +980,14 @@
           </widget>
          </item>
 
-         <item row="17" column="0">
+         <item row="18" column="0">
           <widget class="QLabel" name="label_36">
            <property name="text">
             <string>Line height (header)</string>
            </property>
           </widget>
          </item>
-         <item row="17" column="1">
+         <item row="18" column="1">
           <widget class="QDoubleSpinBox" name="line_height_h">
            <property name="suffix">
             <string> px</string>
@@ -978,14 +1001,14 @@
           </widget>
          </item>
 
-         <item row="18" column="0">
+         <item row="19" column="0">
           <widget class="QLabel" name="label_37">
            <property name="text">
             <string>Indentation</string>
            </property>
           </widget>
          </item>
-         <item row="18" column="1">
+         <item row="19" column="1">
           <layout class="QHBoxLayout" name="indent_container">
 
            <item>
@@ -1075,14 +1098,14 @@
           </layout>
          </item>
 
-         <item row="19" column="0">
+         <item row="20" column="0">
           <widget class="QLabel" name="label_17">
            <property name="text">
             <string>Presets</string>
            </property>
           </widget>
          </item>
-         <item row="19" column="1">
+         <item row="20" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QComboBox" name="presets"/>
@@ -1303,7 +1326,8 @@
   <tabstop>link_foreign_prefix</tabstop>
   <tabstop>quote_change_color</tabstop>
   <tabstop>auto_theme</tabstop>
-  <tabstop>page_margin</tabstop>
+  <tabstop>page_margin_h</tabstop>
+  <tabstop>page_margin_v</tabstop>
   <tabstop>enable_justify_text</tabstop>
   <tabstop>enable_text_width</tabstop>
   <tabstop>text_width</tabstop>

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -896,37 +896,55 @@
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QCheckBox" name="enable_text_width">
+             <property name="text">
+              <string>Enable text width limit</string>
+             </property>
+             <property name="toolTip">
+              <string>Whether to limit the width of formatted text on the page or not.</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
+
          <item row="15" column="0">
+          <widget class="QLabel" name="label_38">
+           <property name="text">
+            <string>Text width limit</string>
+           </property>
+           <property name="toolTip">
+            <string>Preferred width of formatted text on the page.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="15" column="1">
+          <widget class="QSpinBox" name="text_width">
+           <property name="minimum">
+            <number>300</number>
+           </property>
+           <property name="value">
+            <number>900</number>
+           </property>
+           <property name="maximum">
+            <number>2000</number>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+          </widget>
+         </item>
+
+         <item row="16" column="0">
           <widget class="QLabel" name="label_35">
            <property name="text">
             <string>Line height (paragraph)</string>
            </property>
           </widget>
          </item>
-         <item row="15" column="1">
-          <widget class="QDoubleSpinBox" name="line_height_p">
-           <property name="suffix">
-            <string> px</string>
-           </property>
-           <property name="decimals">
-            <number>0</number>
-           </property>
-           <property name="maximum">
-            <double>30</double>
-           </property>
-          </widget>
-         </item>
-         <item row="16" column="0">
-          <widget class="QLabel" name="label_36">
-           <property name="text">
-            <string>Line height (header)</string>
-           </property>
-          </widget>
-         </item>
          <item row="16" column="1">
-          <widget class="QDoubleSpinBox" name="line_height_h">
+          <widget class="QDoubleSpinBox" name="line_height_p">
            <property name="suffix">
             <string> px</string>
            </property>
@@ -940,13 +958,34 @@
          </item>
 
          <item row="17" column="0">
+          <widget class="QLabel" name="label_36">
+           <property name="text">
+            <string>Line height (header)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="17" column="1">
+          <widget class="QDoubleSpinBox" name="line_height_h">
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <double>30</double>
+           </property>
+          </widget>
+         </item>
+
+         <item row="18" column="0">
           <widget class="QLabel" name="label_37">
            <property name="text">
             <string>Indentation</string>
            </property>
           </widget>
          </item>
-         <item row="17" column="1">
+         <item row="18" column="1">
           <layout class="QHBoxLayout" name="indent_container">
 
            <item>
@@ -1036,7 +1075,14 @@
           </layout>
          </item>
 
-         <item row="18" column="1">
+         <item row="19" column="0">
+          <widget class="QLabel" name="label_17">
+           <property name="text">
+            <string>Presets</string>
+           </property>
+          </widget>
+         </item>
+         <item row="19" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QComboBox" name="presets"/>
@@ -1111,13 +1157,6 @@
             </widget>
            </item>
           </layout>
-         </item>
-         <item row="18" column="0">
-          <widget class="QLabel" name="label_17">
-           <property name="text">
-            <string>Presets</string>
-           </property>
-          </widget>
          </item>
          <item row="11" column="0">
           <widget class="QLabel" name="label_21">
@@ -1266,6 +1305,8 @@
   <tabstop>auto_theme</tabstop>
   <tabstop>page_margin</tabstop>
   <tabstop>enable_justify_text</tabstop>
+  <tabstop>enable_text_width</tabstop>
+  <tabstop>text_width</tabstop>
   <tabstop>line_height_p</tabstop>
   <tabstop>line_height_h</tabstop>
   <tabstop>indent_p</tabstop>

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -134,7 +134,8 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     cross_scheme_link_color(0x09, 0x60, 0xa7),
     internal_link_prefix("→ "),
     external_link_prefix("⇒ "),
-    margin(55.0),
+    margin_h(30.0),
+    margin_v(55.0),
     text_width(900),
     ansi_colors({"black", "darkred", "darkgreen", "darkgoldenrod",
         "darkblue", "darkmagenta", "darkcyan", "lightgray",
@@ -225,7 +226,8 @@ bool DocumentStyle::save(QSettings &settings) const
     settings.setValue("background_color", background_color.name());
     settings.setValue("blockquote_color", blockquote_color.name());
 
-    settings.setValue("margins", margin);
+    settings.setValue("margins_h", margin_h);
+    settings.setValue("margins_v", margin_v);
 
     settings.setValue("ansi_colors", ansi_colors);
 
@@ -317,7 +319,7 @@ bool DocumentStyle::load(QSettings &settings)
             internal_link_prefix = settings.value("internal_link_prefix").toString();
             external_link_prefix = settings.value("external_link_prefix").toString();
 
-            margin = settings.value("margins").toDouble();
+            margin_h = margin_v = settings.value("margins").toDouble();
             theme = Theme(settings.value("theme").toInt());
         }
         break;
@@ -328,7 +330,8 @@ bool DocumentStyle::load(QSettings &settings)
         background_color = QColor { settings.value("background_color", background_color.name()).toString() };
         blockquote_color = QColor { settings.value("blockquote_color", blockquote_color.name()).toString() };
 
-        margin = settings.value("margins", 55).toInt();
+        margin_h = settings.value("margins_h", 30).toInt();
+        margin_v = settings.value("margins_v", 55).toInt();
 
         QStringList default_colors = {"black", "darkred", "darkgreen", "darkgoldenrod",
             "darkblue", "darkmagenta", "darkcyan", "lightgray",

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -135,11 +135,13 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     internal_link_prefix("→ "),
     external_link_prefix("⇒ "),
     margin(55.0),
+    text_width(900),
     ansi_colors({"black", "darkred", "darkgreen", "darkgoldenrod",
         "darkblue", "darkmagenta", "darkcyan", "lightgray",
         "gray", "red", "green", "goldenrod",
         "lightblue", "magenta", "cyan", "white"}),
     justify_text(true),
+    text_width_enabled(true),
     line_height_p(5.0),
     line_height_h(0.0),
     indent_bq(2), indent_p(1), indent_h(0), indent_l(2)
@@ -273,6 +275,8 @@ bool DocumentStyle::save(QSettings &settings) const
         settings.beginGroup("Formatting");
 
         settings.setValue("justify_text", justify_text);
+        settings.setValue("text_width_enabled", text_width_enabled);
+        settings.setValue("text_width", text_width);
         settings.setValue("line_height_p", line_height_p);
         settings.setValue("line_height_h", line_height_h);
         settings.setValue("indent_bq", indent_bq);
@@ -378,6 +382,8 @@ bool DocumentStyle::load(QSettings &settings)
             settings.beginGroup("Formatting");
 
             justify_text = settings.value("justify_text", justify_text).toBool();
+            text_width_enabled = settings.value("text_width_enabled", text_width_enabled).toBool();
+            text_width = settings.value("text_width", text_width).toInt();
             line_height_p = settings.value("line_height_p", line_height_p).toDouble();
             line_height_h = settings.value("line_height_h", line_height_h).toDouble();
             indent_bq = settings.value("indent_bq", indent_bq).toInt();

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -49,7 +49,7 @@ struct DocumentStyle
     QString internal_link_prefix;
     QString external_link_prefix;
 
-    double margin;
+    double margin_h, margin_v;
 
     double text_width;
 

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -51,9 +51,11 @@ struct DocumentStyle
 
     double margin;
 
+    double text_width;
+
     QStringList ansi_colors;
 
-    bool justify_text;
+    bool justify_text, text_width_enabled;
     double line_height_p;
     double line_height_h;
     int indent_bq, indent_p, indent_h, indent_l;

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -1,4 +1,5 @@
 #include "geminirenderer.hpp"
+#include "renderhelpers.hpp"
 
 #include <QTextList>
 #include <QTextBlock>
@@ -35,7 +36,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
     TextStyleInstance text_style { themed_style };
 
     std::unique_ptr<GeminiDocument> result = std::make_unique<GeminiDocument>();
-    result->setDocumentMargin(themed_style.margin);
+    renderhelpers::setPageMargins(result.get(), themed_style.margin_h, themed_style.margin_v);
     result->setIndentWidth(20);
 
     bool emit_fancy_text = kristall::options.enable_text_decoration;

--- a/src/renderers/gophermaprenderer.cpp
+++ b/src/renderers/gophermaprenderer.cpp
@@ -141,7 +141,7 @@ std::unique_ptr<QTextDocument> GophermapRenderer::render(const QByteArray &input
         if (type == 'i')
         {
             const QString escapeRenderInput = title + "\n";
-            RenderEscapeCodes(escapeRenderInput.toUtf8(), standard, cursor);
+            renderhelpers::renderEscapeCodes(escapeRenderInput.toUtf8(), standard, cursor);
         }
         else
         {

--- a/src/renderers/gophermaprenderer.cpp
+++ b/src/renderers/gophermaprenderer.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<QTextDocument> GophermapRenderer::render(const QByteArray &input
     bool emit_text_only = (kristall::options.gophermap_display == GenericSettings::PlainText);
 
     std::unique_ptr<QTextDocument> result = std::make_unique<QTextDocument>();
-    result->setDocumentMargin(themed_style.margin);
+    renderhelpers::setPageMargins(result.get(), themed_style.margin_h, themed_style.margin_v);
 
     if(not emit_text_only)
     {

--- a/src/renderers/markdownrenderer.cpp
+++ b/src/renderers/markdownrenderer.cpp
@@ -2,6 +2,8 @@
 
 #include "textstyleinstance.hpp"
 
+#include "renderhelpers.hpp"
+
 #include <cmark.h>
 #include <cassert>
 
@@ -316,7 +318,7 @@ std::unique_ptr<QTextDocument> MarkdownRenderer::render(
         return nullptr;
 
     auto doc = std::make_unique<QTextDocument>();
-    doc->setDocumentMargin(style.margin);
+    renderhelpers::setPageMargins(doc.get(), style.margin_h, style.margin_v);
     doc->setIndentWidth(20);
 
     outline.beginBuild();

--- a/src/renderers/plaintextrenderer.cpp
+++ b/src/renderers/plaintextrenderer.cpp
@@ -14,7 +14,7 @@ std::unique_ptr<QTextDocument> PlainTextRenderer::render(const QByteArray &input
     standard.setForeground(style.preformatted_color);
 
     std::unique_ptr<QTextDocument> result = std::make_unique<QTextDocument>();
-    result->setDocumentMargin(style.margin);
+    renderhelpers::setPageMargins(result.get(), style.margin_h, style.margin_v);
 
     QTextCursor cursor { result.get() };
     RenderEscapeCodes(input, standard, cursor);

--- a/src/renderers/plaintextrenderer.cpp
+++ b/src/renderers/plaintextrenderer.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<QTextDocument> PlainTextRenderer::render(const QByteArray &input
     renderhelpers::setPageMargins(result.get(), style.margin_h, style.margin_v);
 
     QTextCursor cursor { result.get() };
-    RenderEscapeCodes(input, standard, cursor);
+    renderhelpers::renderEscapeCodes(input, standard, cursor);
 
     return result;
 }

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -23,7 +23,7 @@
 static constexpr const char escapeString = '\033';
 bool inverted{false};
 
-void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
+static void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
 {
     QColor color;
 
@@ -57,7 +57,7 @@ void setColor(QTextCharFormat& format, unsigned char n, bool bg=false)
         format.setForeground(color);
 }
 
-QString parseNumber(const QString& input, QString::const_iterator& it)
+static QString parseNumber(const QString& input, QString::const_iterator& it)
 {
     QString result;
     while (it != input.cend())
@@ -70,7 +70,7 @@ QString parseNumber(const QString& input, QString::const_iterator& it)
     return result;
 }
 
-void parseSGR(
+static void parseSGR(
     std::vector<unsigned char>& args,
     const QString& input,
     QString::const_iterator& it,
@@ -223,7 +223,7 @@ void parseSGR(
     }
 }
 
-std::vector<unsigned char> parseNumericArguments(const QString& input, QString::const_iterator& it)
+static std::vector<unsigned char> parseNumericArguments(const QString& input, QString::const_iterator& it)
 {
     std::vector<unsigned char> result;
     while (it != input.end())
@@ -247,7 +247,7 @@ std::vector<unsigned char> parseNumericArguments(const QString& input, QString::
     return result;
 }
 
-void parseCSI(
+static void parseCSI(
     const QString& input,
     QString::const_iterator& it,
     QTextCharFormat& format,
@@ -324,7 +324,8 @@ void parseCSI(
     }
 }
 
-void RenderEscapeCodes(const QByteArray &input, const QTextCharFormat& format, QTextCursor& cursor)
+void renderhelpers::renderEscapeCodes(const QByteArray &input,
+    const QTextCharFormat& format, QTextCursor& cursor)
 {
     auto textFormat = format;
     const auto tokens = input.split(escapeString);

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -2,7 +2,7 @@
  * @TODO I'm hardcoding this to ANSI for now, as it's the most common.
  *       Ideally we should have configurable control characters for various
  *       types of terminals that could be emulated via a standard termcap file.
- * @NOTE ANSI escape sequence reference: 
+ * @NOTE ANSI escape sequence reference:
  *       https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences
  *       Note that escape sequences for other terminal types are a thing, and
  *       currently aren't implemented yet as mentioned in the TODO above, eg:
@@ -14,6 +14,8 @@
 #include <QByteArray>
 #include <QString>
 #include <QTextCursor>
+#include <QTextFrame>
+#include <QTextFrameFormat>
 
 #include <string>
 #include <iostream>
@@ -79,7 +81,7 @@ void parseSGR(
     if (args.empty()) return;
     for (auto it = args.cbegin(); it != args.cend(); ++it)
     {
-        /// @TODO A whole bunch of unimplemented SGR codes are unimplemented 
+        /// @TODO A whole bunch of unimplemented SGR codes are unimplemented
         ///       yet (eg: blink or font switching)
         enum {
             Reset = 0, Bold, Light, Italic, Underline,
@@ -347,3 +349,13 @@ void RenderEscapeCodes(const QByteArray &input, const QTextCharFormat& format, Q
     }
 }
 
+void renderhelpers::setPageMargins(QTextDocument *doc, int mh, int mv)
+{
+    QTextFrame *root = doc->rootFrame();
+    QTextFrameFormat fmt = root->frameFormat();
+    fmt.setLeftMargin(mh);
+    fmt.setRightMargin(mh);
+    fmt.setTopMargin(mv);
+    fmt.setBottomMargin(mv);
+    root->setFrameFormat(fmt);
+}

--- a/src/renderers/renderhelpers.hpp
+++ b/src/renderers/renderhelpers.hpp
@@ -3,7 +3,13 @@
 
 #include <QByteArray>
 #include <QTextCursor>
+#include <QTextDocument>
 
 void RenderEscapeCodes(const QByteArray &input, const QTextCharFormat& format, QTextCursor& cursor);
+
+namespace renderhelpers
+{
+    void setPageMargins(QTextDocument *doc, int mh, int mv);
+}
 
 #endif

--- a/src/renderers/renderhelpers.hpp
+++ b/src/renderers/renderhelpers.hpp
@@ -5,10 +5,10 @@
 #include <QTextCursor>
 #include <QTextDocument>
 
-void RenderEscapeCodes(const QByteArray &input, const QTextCharFormat& format, QTextCursor& cursor);
-
 namespace renderhelpers
 {
+    void renderEscapeCodes(const QByteArray &input, const QTextCharFormat& format, QTextCursor& cursor);
+
     void setPageMargins(QTextDocument *doc, int mh, int mv);
 }
 


### PR DESCRIPTION
The main feature of this PR is a new 'maximum text width' option, which helps enhance readability and makes kristall look a lot nicer! This feature should also work with most HTML pages fine

Example with default 900px width:
![image](https://user-images.githubusercontent.com/42143005/107840718-40736f00-6e09-11eb-9592-fec59eda67b7.png)

See 4eefb7d1531fd00f9ae1b185d11ef87a350fc1c2 for implementation details of how this was done

The old layout is still available via a preference.

Additionally, the margins have been split into two preferences now; 'left/right', (horizontal) and 'top/bottom' (vertical). When using maximum text width as shown above, the horizontal margin is used when the window is smaller than the configured text width:
![image](https://user-images.githubusercontent.com/42143005/107840764-a9f37d80-6e09-11eb-8ba8-93a98d8571a6.png)
(note the 55px margin between the text and window edge)

Closes #91 
Closes #44 