### PR TITLE
Add support for typographer quotes

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -249,6 +249,12 @@ void SettingsDialog::setOptions(const GenericSettings &options)
         this->ui->urlbarhl_none->setChecked(true);
     }
 
+    if(this->current_options.fancy_quotes) {
+        this->ui->fancyquotes_on->setChecked(true);
+    } else {
+        this->ui->fancyquotes_off->setChecked(true);
+    }
+
     this->ui->max_redirects->setValue(this->current_options.max_redirections);
 
     this->ui->redirection_mode->setCurrentIndex(0);
@@ -714,6 +720,16 @@ void SettingsDialog::on_urlbarhl_fancy_clicked()
 void SettingsDialog::on_urlbarhl_none_clicked()
 {
     this->current_options.fancy_urlbar = false;
+}
+
+void SettingsDialog::on_fancyquotes_on_clicked()
+{
+    this->current_options.fancy_quotes = true;
+}
+
+void SettingsDialog::on_fancyquotes_off_clicked()
+{
+    this->current_options.fancy_quotes = false;
 }
 
 void SettingsDialog::on_redirection_mode_currentIndexChanged(int index)

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -112,28 +112,25 @@ private slots:
     void on_ui_density_currentIndexChanged(int index);
 
     void on_fancypants_on_clicked();
-
     void on_fancypants_off_clicked();
 
     void on_texthl_on_clicked();
-
     void on_texthl_off_clicked();
 
     void on_gophermap_icon_clicked();
-
     void on_gophermap_text_clicked();
 
     void on_scheme_os_default_clicked();
-
     void on_scheme_error_clicked();
 
     void on_show_hidden_files_clicked();
-
     void on_hide_hidden_files_clicked();
 
     void on_urlbarhl_fancy_clicked();
-
     void on_urlbarhl_none_clicked();
+
+    void on_fancyquotes_on_clicked();
+    void on_fancyquotes_off_clicked();
 
     void on_redirection_mode_currentIndexChanged(int index);
 
@@ -142,13 +139,10 @@ private slots:
     void on_network_timeout_valueChanged(int arg1);
 
     void on_enable_home_btn_clicked(bool arg1);
-
     void on_enable_newtab_btn_clicked(bool arg1);
 
     void on_cache_limit_valueChanged(int limit);
-
     void on_cache_threshold_valueChanged(int thres);
-
     void on_cache_life_valueChanged(int life);
 
 private:

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -314,37 +314,71 @@
         </layout>
        </item>
        <item row="10" column="0">
+        <widget class="QLabel" name="label_39">
+         <property name="text">
+          <string>Use typographer's quotes</string>
+         </property>
+         <property name="toolTip">
+          <string>Replace single and double quotes with curly typographer quotes.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_10">
+         <item>
+          <widget class="QRadioButton" name="fancyquotes_on">
+           <property name="text">
+            <string>On</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">quotesBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="fancyquotes_off">
+           <property name="text">
+            <string>Off</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">quotesBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="11" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -357,14 +391,14 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_99">
          <item>
           <widget class="QCheckBox" name="enable_home_btn">
@@ -382,7 +416,7 @@
          </item>
         </layout>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="label_30">
          <property name="text">
           <string>Total cache size limit</string>
@@ -392,7 +426,7 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="15" column="1">
         <widget class="QSpinBox" name="cache_limit">
          <property name="suffix">
           <string> KiB</string>
@@ -406,7 +440,7 @@
         </widget>
        </item>
 
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item size threshold</string>
@@ -416,7 +450,7 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <widget class="QSpinBox" name="cache_threshold">
          <property name="suffix">
           <string> KiB</string>
@@ -430,7 +464,7 @@
         </widget>
        </item>
 
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item life</string>
@@ -440,7 +474,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QSpinBox" name="cache_life">
          <property name="suffix">
           <string> minutes</string>
@@ -1240,11 +1274,16 @@
   <tabstop>hide_hidden_files</tabstop>
   <tabstop>urlbarhl_fancy</tabstop>
   <tabstop>urlbarhl_none</tabstop>
+  <tabstop>fancyquotes_on</tabstop>
+  <tabstop>fancyquotes_off</tabstop>
   <tabstop>max_redirects</tabstop>
   <tabstop>redirection_mode</tabstop>
   <tabstop>network_timeout</tabstop>
   <tabstop>enable_home_btn</tabstop>
   <tabstop>enable_newtab_btn</tabstop>
+  <tabstop>cache_limit</tabstop>
+  <tabstop>cache_threshold</tabstop>
+  <tabstop>cache_life</tabstop>
   <tabstop>bg_change_color</tabstop>
   <tabstop>style_preview</tabstop>
   <tabstop>std_change_font</tabstop>
@@ -1322,5 +1361,6 @@
   <buttongroup name="buttonGroup"/>
   <buttongroup name="hiddenFilesBtnGroup"/>
   <buttongroup name="urlbarBtnGroup"/>
+  <buttongroup name="quotesBtnGroup"/>
  </buttongroups>
 </ui>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -58,6 +58,7 @@ struct GenericSettings
     bool use_os_scheme_handler = false;
     bool show_hidden_files_in_dirs = false;
     bool fancy_urlbar = true;
+    bool fancy_quotes = true;
 
     // This is set automatically
     QColor fancy_urlbar_dim_colour;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -364,6 +364,8 @@ void GenericSettings::load(QSettings &settings)
 
     fancy_urlbar = settings.value("fancy_urlbar", true).toBool();
 
+    fancy_quotes = settings.value("fancy_quotes", true).toBool();
+
     max_redirections = settings.value("max_redirections", 5).toInt();
     redirection_policy = RedirectionWarning(settings.value("redirection_policy ", WarnOnHostChange).toInt());
 
@@ -399,6 +401,7 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("use_os_scheme_handler", use_os_scheme_handler);
     settings.setValue("show_hidden_files_in_dirs", show_hidden_files_in_dirs);
     settings.setValue("fancy_urlbar", fancy_urlbar);
+    settings.setValue("fancy_quotes", fancy_quotes);
     settings.setValue("max_redirections", max_redirections);
     settings.setValue("redirection_policy", int(redirection_policy));
     settings.setValue("network_timeout", network_timeout);

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -200,8 +200,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
                 {
                     link = trim_whitespace(part);
                     title = trim_whitespace(part);
-                    replace_quotes(title);
                 }
+                replace_quotes(title);
 
                 auto local_url = QUrl(link);
 

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -334,6 +334,9 @@ GeminiDocument::~GeminiDocument()
  */
 static QByteArray replace_quotes(QByteArray &line)
 {
+    if (!kristall::options.fancy_quotes)
+        return line;
+
     int last_d = -1,
         last_s = -1;
 
@@ -367,6 +370,14 @@ static QByteArray replace_quotes(QByteArray &line)
                 if (i > 0 && line[i - 1] != ' ')
                 {
                     line.replace(i, 1, QString("’").toUtf8());
+                    continue;
+                }
+
+                // For shortenings like 'till
+                int len = line.length();
+                if ((i + 1) < len && line[i + 1] != ' ')
+                {
+                    line.replace(i, 1, QString("‘").toUtf8());
                     continue;
                 }
 


### PR DESCRIPTION
This replaces double and single quotation marks (", ' respectively) with fancier unicode quotes (‘, ’, “, ”)

It can also be disabled in the preferences (enabled by default)

The implementation works great in all the cases I could think of. For example:

![image](https://user-images.githubusercontent.com/42143005/107845326-bb02b580-6e2e-11eb-8c29-9db24068c928.png)

There is however one caveat to this, and that is the **searchbox** feature isn't as intuitive. This is because QTextEdit::find doesn't provide a built-in method of matching the different quote types to each other. This means that if someone was searching for the word "don't" in the searchbox, and had typographer quotes enabled, it would not return any results. This could possibly be fixed in future by using a regex, or some other method.