### PR TITLE
Search box improvements: quotation mark matching

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1545,7 +1545,7 @@ void BrowserTab::disableClientCertificate()
 bool BrowserTab::searchBoxFind(QString text, bool backward)
 {
     // First we escape the query to be suitable to use inside a regex pattern.
-    // https://stackoverflow.com/a/6969486
+    // https://stackoverflow.com/a/3561711
     static const QRegularExpression ESCAPE_REGEX = QRegularExpression(R"(([-\/\\^$*+?.()|[\]{}]))");
     text.replace(ESCAPE_REGEX, "\\\\1");
 

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1558,7 +1558,11 @@ bool BrowserTab::searchBoxFind(QString text, bool backward)
 
     // Perform search using our new regex
     return this->ui->text_browser->find(
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
         QRegularExpression(text, QRegularExpression::CaseInsensitiveOption),
+#else
+        QRegExp(text, Qt::CaseInsensitive),
+#endif
         backward ? QTextDocument::FindBackward : QTextDocument::FindFlags());
 }
 

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -189,6 +189,8 @@ private:
     bool enableClientCertificate(CryptoIdentity const & ident);
     void disableClientCertificate();
 
+    bool searchBoxFind(QString text, bool backward=false);
+
 protected:
     void resizeEvent(QResizeEvent * event);
 


### PR DESCRIPTION
Fixes the issue mentioned in #150 

Search box queries now work for unicode quotation mark types. So e.g: searching for the word `can't` in a page that uses unicode quotation marks will now work correctly. This was achieved by using some regex trickery.