### PR TITLE
Basic search engine functionality added

### DIFF
--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -90,6 +90,18 @@ This tab contains an unsorted list of settings that allow you to tweak Kristalls
 
 [Start Page] is the URL to the page that will be loaded for new tabs. Default is "about:favourites".
 
+[Search Engine] is the search engine to use when typing non-URLs in the URL bar. A handful of Gemini search engines are provided as a drop-down. If you would like to specify your own, specify it in a format similar to the following:
+
+```
+gemini://example.com/search?%1
+```
+
+Note the "%1" at the end of the URL. This is where search queries will be inserted. This *must* be provided in order for Kristall to work with the search engine correctly. Be aware that search engine URLs can vary. For example, a different search engine may appear like so:
+
+```
+gemini://example2.com/search/another/%1
+```
+
 [Enabled Protocols] allows you to fine-tune which protocols are fetched by Kristall. By default, only Gemini is enabled, all other protocols are disabled. Disabled protocols are either not served with an error message or forwarded to your OS handler for that URL scheme.
 
 [Text Rendering] allows to control whether Kristall parses text input files or not. This is usually set to [Fancy] which renders text/html, text/gemini, text/markdown and text/gophermap to a nice, hyperlinked display. When set to [Always plain text], Kristall will display all text/* files as plaintext files instead. This may be inconvenient, but necessary for misparsed sites.

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -304,8 +304,19 @@ void BrowserTab::on_url_bar_returnPressed()
         else
         {
             // Use the text as a search query.
-            static const QString search_engine = "gemini://gus.guru/search?%1";
-            url = QUrl{QString(search_engine).arg(this->ui->url_bar->text())};
+            if (kristall::options.search_engine.isEmpty() ||
+                !kristall::options.search_engine.contains("%1"))
+            {
+                QMessageBox::warning(this,
+                    "Kristall",
+                    "No search engine is configured.\n"
+                    "Please configure one in the settings to allow searching via the URL bar.\n\n"
+                    "See the Help menu for additional information."
+                    );
+                return;
+            }
+            url = QUrl{QString(kristall::options.search_engine)
+                .arg(this->ui->url_bar->text())};
         }
     }
 

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -292,7 +292,21 @@ void BrowserTab::on_url_bar_returnPressed()
 
     if (url.scheme().isEmpty())
     {
-        url = QUrl{"gemini://" + this->ui->url_bar->text()};
+        // Need this to get the validation below to work.
+        url.setUrl("internal://" + this->ui->url_bar->text());
+
+        // We check if there is at least a TLD so that single words
+        // are assumed to be searches.
+        if (url.isValid() && url.host().contains("."))
+        {
+            url = QUrl{"gemini://" + urltext};
+        }
+        else
+        {
+            // Use the text as a search query.
+            static const QString search_engine = "gemini://gus.guru/search?%1";
+            url = QUrl{QString(search_engine).arg(this->ui->url_bar->text())};
+        }
     }
 
     this->ui->url_bar->clearFocus();

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -220,6 +220,7 @@ void SettingsDialog::setOptions(const GenericSettings &options)
 
     this->ui->search_engine->clear();
     this->ui->search_engine->setEditText(this->current_options.search_engine);
+    this->ui->search_engine->lineEdit()->setPlaceholderText("URL with '%1' in place of query");
     this->ui->search_engine->addItem("gemini://geminispace.info/search?%1");
     this->ui->search_engine->addItem("gemini://gus.guru/search?%1");
     this->ui->search_engine->addItem("gemini://houston.coder.town/search?%1");

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -218,6 +218,12 @@ void SettingsDialog::setOptions(const GenericSettings &options)
 
     this->ui->start_page->setText(this->current_options.start_page);
 
+    this->ui->search_engine->clear();
+    this->ui->search_engine->setEditText(this->current_options.search_engine);
+    this->ui->search_engine->addItem("gemini://geminispace.info/search?%1");
+    this->ui->search_engine->addItem("gemini://gus.guru/search?%1");
+    this->ui->search_engine->addItem("gemini://houston.coder.town/search?%1");
+
     if(this->current_options.gophermap_display == GenericSettings::PlainText) {
         this->ui->gophermap_text->setChecked(true);
     } else {
@@ -668,6 +674,11 @@ void SettingsDialog::on_preset_export_clicked()
 void SettingsDialog::on_start_page_textChanged(const QString &start_page)
 {
     this->current_options.start_page = start_page;
+}
+
+void SettingsDialog::on_search_engine_currentTextChanged(const QString &search_engine)
+{
+    this->current_options.search_engine = search_engine;
 }
 
 void SettingsDialog::on_ui_theme_currentIndexChanged(int index)

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -112,6 +112,8 @@ private slots:
 
     void on_start_page_textChanged(const QString &arg1);
 
+    void on_search_engine_currentTextChanged(const QString &arg1);
+
     void on_ui_theme_currentIndexChanged(int index);
 
     void on_ui_density_currentIndexChanged(int index);

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -52,6 +52,7 @@
        <item row="1" column="1">
         <widget class="QComboBox" name="ui_density"/>
        </item>
+
        <item row="2" column="0">
         <widget class="QLabel" name="label_14">
          <property name="text">
@@ -67,13 +68,30 @@
         </widget>
        </item>
        <item row="3" column="0">
+        <widget class="QLabel" name="label_40">
+         <property name="text">
+          <string>Search engine:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="search_engine">
+         <property name="editable">
+          <bool>true</bool>
+         </property>
+         <property name="placeholderText">
+           <string>Enter URL with '%1' in place of query</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>Enabled Protocols</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QCheckBox" name="enable_gemini">
@@ -118,14 +136,14 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_19">
          <property name="text">
           <string>Text Rendering</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QRadioButton" name="fancypants_on">
@@ -152,14 +170,14 @@
          </item>
         </layout>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_18">
          <property name="text">
           <string>Enable text highlights</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QRadioButton" name="texthl_on">
@@ -186,14 +204,14 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_20">
          <property name="text">
           <string>Gopher Map</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QRadioButton" name="gophermap_icon">
@@ -220,14 +238,14 @@
          </item>
         </layout>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_22">
          <property name="text">
           <string>Unknown Scheme</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
           <widget class="QRadioButton" name="scheme_os_default">
@@ -251,14 +269,14 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_23">
          <property name="text">
           <string>Hidden files in file:// directories</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_8">
          <item>
           <widget class="QRadioButton" name="show_hidden_files">
@@ -282,14 +300,14 @@
          </item>
         </layout>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_24">
          <property name="text">
           <string>URL bar highlights</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
           <widget class="QRadioButton" name="urlbarhl_fancy">
@@ -313,7 +331,7 @@
          </item>
         </layout>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_39">
          <property name="text">
           <string>Use typographer's quotes</string>
@@ -323,7 +341,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_10">
          <item>
           <widget class="QRadioButton" name="fancyquotes_on">
@@ -347,38 +365,38 @@
          </item>
         </layout>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -391,14 +409,14 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="15" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_99">
          <item>
           <widget class="QCheckBox" name="enable_home_btn">
@@ -416,7 +434,7 @@
          </item>
         </layout>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_30">
          <property name="text">
           <string>Total cache size limit</string>
@@ -426,7 +444,7 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <widget class="QSpinBox" name="cache_limit">
          <property name="suffix">
           <string> KiB</string>
@@ -440,7 +458,7 @@
         </widget>
        </item>
 
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item size threshold</string>
@@ -450,7 +468,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QSpinBox" name="cache_threshold">
          <property name="suffix">
           <string> KiB</string>
@@ -464,7 +482,7 @@
         </widget>
        </item>
 
-       <item row="17" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item life</string>
@@ -474,7 +492,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <widget class="QSpinBox" name="cache_life">
          <property name="suffix">
           <string> minutes</string>
@@ -1319,6 +1337,7 @@
   <tabstop>ui_theme</tabstop>
   <tabstop>ui_density</tabstop>
   <tabstop>start_page</tabstop>
+  <tabstop>search_engine</tabstop>
   <tabstop>enable_gemini</tabstop>
   <tabstop>enable_gopher</tabstop>
   <tabstop>enable_finger</tabstop>

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -79,9 +79,6 @@
          <property name="editable">
           <bool>true</bool>
          </property>
-         <property name="placeholderText">
-           <string>Enter URL with '%1' in place of query</string>
-         </property>
         </widget>
        </item>
        <item row="4" column="0">

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -51,6 +51,7 @@ struct GenericSettings
     };
 
     QString start_page = "about:favourites";
+    QString search_engine = "gemini://geminispace.info/search?%1";
     Theme theme = Theme::light;
     UIDensity ui_density = UIDensity::compact;
     TextDisplay text_display = FormattedText;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,6 +331,7 @@ void GenericSettings::load(QSettings &settings)
 {
     network_timeout = settings.value("network_timeout", 5000).toInt();
     start_page = settings.value("start_page", "about:favourites").toString();
+    search_engine = settings.value("search_engine", "gemini://geminispace.info/search?%1").toString();
 
     if(settings.value("text_display", "fancy").toString() == "plain")
         text_display = PlainText;
@@ -380,6 +381,7 @@ void GenericSettings::load(QSettings &settings)
 void GenericSettings::save(QSettings &settings) const
 {
     settings.setValue("start_page", this->start_page);
+    settings.setValue("search_engine", this->search_engine);
     settings.setValue("text_display", (text_display == FormattedText) ? "fancy" : "plain");
     settings.setValue("text_decoration", enable_text_decoration);
     QString theme_name = "os_default";


### PR DESCRIPTION
The URL bar can now perform search queries using a search engine specified in the preferences. This only applies to URL bar entries that appear to not be a URL of any kind.

For example, when the following are entered in the URL bar:
- `gemini.circumlunar.space` -> navigates to `gemini://gemini.circumlunar.space`
- `test` -> performs search query for "test"
- `gemini.circumlunar.space test` -> performs search query (note the space)
- `gemini://test` -> navigates to `gemini://test`

By default the search engine is geminispace.info (happy to change this to something else if wanted). There are 3 search engine options shown to the user in the preferences so that it's easy to switch between common ones.

A section in the help.gemini file was also added for the preference