### PR TITLE
Improved blockquotes

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -90,6 +90,11 @@ BrowserTab::BrowserTab(MainWindow *mainWindow) : QWidget(nullptr),
 
     this->ui->text_browser->verticalScrollBar()->setTracking(true);
 
+    // We hide horizontal scroll bars for now, however mouse-scrolling (overshooting?)
+    // causes the page to still scroll horizontally. TODO: Fix this
+    this->ui->text_browser->horizontalScrollBar()->setEnabled(false);
+    this->ui->text_browser->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
     connect(this->ui->url_bar, &SearchBar::escapePressed, this, &BrowserTab::on_url_bar_escapePressed);
 
     this->network_timeout_timer.setSingleShot(true);

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -138,7 +138,7 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
         .arg(this->current_style.background_color.name(), "#FF00FF"));
 
     ui->quote_preview->setStyleSheet(COLOR_STYLE
-        .arg(this->current_style.blockquote_color.name(), "#FF00FF"));
+        .arg(this->current_style.blockquote_bgcolor.name(), "#FF00FF"));
 
     ui->link_local_preview->setStyleSheet(COLOR_STYLE
         .arg(this->current_style.background_color.name(), this->current_style.internal_link_color.name()));
@@ -154,6 +154,7 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
     setFontAndColor(this->ui->h1_preview, this->current_style.h1_font, this->current_style.h1_color);
     setFontAndColor(this->ui->h2_preview, this->current_style.h2_font, this->current_style.h2_color);
     setFontAndColor(this->ui->h3_preview, this->current_style.h3_font, this->current_style.h3_color);
+    setFontAndColor(this->ui->bq_preview, this->current_style.blockquote_font, this->current_style.blockquote_fgcolor);
 
     this->reloadStylePreview();
 }
@@ -359,6 +360,11 @@ void SettingsDialog::on_h3_change_font_clicked()
     updateFont(current_style.h3_font);
 }
 
+void SettingsDialog::on_bq_change_font_clicked()
+{
+    updateFont(current_style.blockquote_font);
+}
+
 void SettingsDialog::updateColor(QColor &input)
 {
     QColorDialog dialog { this };
@@ -396,6 +402,11 @@ void SettingsDialog::on_h3_change_color_clicked()
     updateColor(current_style.h3_color);
 }
 
+void SettingsDialog::on_bq_change_color_clicked()
+{
+    updateColor(current_style.blockquote_fgcolor);
+}
+
 void SettingsDialog::on_bg_change_color_clicked()
 {
     updateColor(current_style.background_color);
@@ -417,7 +428,7 @@ void SettingsDialog::on_link_cross_change_color_clicked()
 }
 void SettingsDialog::on_quote_change_color_clicked()
 {
-    updateColor(current_style.blockquote_color);
+    updateColor(current_style.blockquote_bgcolor);
 }
 
 void SettingsDialog::on_link_local_prefix_textChanged(const QString &text)

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -50,6 +50,8 @@ private slots:
 
     void on_h3_change_font_clicked();
 
+    void on_bq_change_font_clicked();
+
     void on_std_change_color_clicked();
 
     void on_pre_change_color_clicked();
@@ -59,6 +61,8 @@ private slots:
     void on_h2_change_color_clicked();
 
     void on_h3_change_color_clicked();
+
+    void on_bq_change_color_clicked();
 
     void on_bg_change_color_clicked();
 

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -723,6 +723,7 @@
            </item>
           </layout>
          </item>
+
          <item row="5" column="0">
           <widget class="QLabel" name="label_6">
            <property name="text">
@@ -772,56 +773,107 @@
            </item>
           </layout>
          </item>
+
          <item row="6" column="0">
+          <widget class="QLabel" name="label_33">
+           <property name="text">
+            <string>Blockquote font</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_24">
+           <item>
+            <widget class="QLabel" name="bq_preview">
+             <property name="styleSheet">
+              <string notr="true">border: 1px solid black;</string>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="text">
+              <string>This font will be used in blockquotes.</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::PlainText</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="bq_change_font">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset theme="font">
+               <normaloff>.</normaloff>.</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="bq_change_color">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset theme="palette">
+               <normaloff>.</normaloff>.</iconset>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+
+         <item row="7" column="0">
           <widget class="QLabel" name="label_7">
            <property name="text">
             <string>Local Link Color</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="8" column="0">
           <widget class="QLabel" name="label_8">
            <property name="text">
             <string>Foreign Link Color</string>
            </property>
           </widget>
          </item>
-         <item row="8" column="0">
+         <item row="9" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
             <string>Cross-Scheme-Color</string>
            </property>
           </widget>
          </item>
-         <item row="9" column="0">
+         <item row="10" column="0">
           <widget class="QLabel" name="label_10">
            <property name="text">
             <string>Local Link Prefix</string>
            </property>
           </widget>
          </item>
-         <item row="10" column="0">
+         <item row="11" column="0">
           <widget class="QLabel" name="label_11">
            <property name="text">
             <string>Extern Link Prefix</string>
            </property>
           </widget>
          </item>
-         <item row="10" column="1">
+         <item row="11" column="1">
           <widget class="QLineEdit" name="link_foreign_prefix">
            <property name="text">
             <string>⇒ </string>
            </property>
           </widget>
          </item>
-         <item row="9" column="1">
+         <item row="10" column="1">
           <widget class="QLineEdit" name="link_local_prefix">
            <property name="text">
             <string>→ </string>
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="7" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_20">
            <item>
             <widget class="QLabel" name="link_local_preview">
@@ -846,7 +898,7 @@
            </item>
           </layout>
          </item>
-         <item row="7" column="1">
+         <item row="8" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_21">
            <item>
             <widget class="QLabel" name="link_foreign_preview">
@@ -871,7 +923,7 @@
            </item>
           </layout>
          </item>
-         <item row="8" column="1">
+         <item row="9" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_22">
            <item>
             <widget class="QLabel" name="link_cross_preview">
@@ -896,25 +948,25 @@
            </item>
           </layout>
          </item>
-         <item row="12" column="0">
+         <item row="13" column="0">
           <widget class="QLabel" name="label_12">
            <property name="text">
             <string>Auto-Theme Generation</string>
            </property>
           </widget>
          </item>
-         <item row="12" column="1">
+         <item row="13" column="1">
           <widget class="QComboBox" name="auto_theme"/>
          </item>
 
-         <item row="13" column="0">
+         <item row="14" column="0">
           <widget class="QLabel" name="label_13">
            <property name="text">
             <string>Left/right Page Margin</string>
            </property>
           </widget>
          </item>
-         <item row="13" column="1">
+         <item row="14" column="1">
           <widget class="QDoubleSpinBox" name="page_margin_h">
            <property name="suffix">
             <string> px</string>
@@ -928,14 +980,14 @@
           </widget>
          </item>
 
-         <item row="14" column="0">
+         <item row="15" column="0">
           <widget class="QLabel" name="label_32">
            <property name="text">
             <string>Top/bottom Page Margin</string>
            </property>
           </widget>
          </item>
-         <item row="14" column="1">
+         <item row="15" column="1">
           <widget class="QDoubleSpinBox" name="page_margin_v">
            <property name="suffix">
             <string> px</string>
@@ -949,14 +1001,14 @@
           </widget>
          </item>
 
-         <item row="15" column="0">
+         <item row="16" column="0">
           <widget class="QLabel" name="label_25">
            <property name="text">
             <string>Other options</string>
            </property>
           </widget>
          </item>
-         <item row="15" column="1">
+         <item row="16" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_98">
            <item>
             <widget class="QCheckBox" name="enable_justify_text">
@@ -981,7 +1033,7 @@
           </layout>
          </item>
 
-         <item row="16" column="0">
+         <item row="17" column="0">
           <widget class="QLabel" name="label_38">
            <property name="text">
             <string>Text width limit</string>
@@ -991,7 +1043,7 @@
            </property>
           </widget>
          </item>
-         <item row="16" column="1">
+         <item row="17" column="1">
           <widget class="QSpinBox" name="text_width">
            <property name="minimum">
             <number>300</number>
@@ -1008,14 +1060,14 @@
           </widget>
          </item>
 
-         <item row="17" column="0">
+         <item row="18" column="0">
           <widget class="QLabel" name="label_35">
            <property name="text">
             <string>Line height (paragraph)</string>
            </property>
           </widget>
          </item>
-         <item row="17" column="1">
+         <item row="18" column="1">
           <widget class="QDoubleSpinBox" name="line_height_p">
            <property name="suffix">
             <string> px</string>
@@ -1029,14 +1081,14 @@
           </widget>
          </item>
 
-         <item row="18" column="0">
+         <item row="19" column="0">
           <widget class="QLabel" name="label_36">
            <property name="text">
             <string>Line height (header)</string>
            </property>
           </widget>
          </item>
-         <item row="18" column="1">
+         <item row="19" column="1">
           <widget class="QDoubleSpinBox" name="line_height_h">
            <property name="suffix">
             <string> px</string>
@@ -1050,14 +1102,14 @@
           </widget>
          </item>
 
-         <item row="19" column="0">
+         <item row="20" column="0">
           <widget class="QLabel" name="label_37">
            <property name="text">
             <string>Indentation</string>
            </property>
           </widget>
          </item>
-         <item row="19" column="1">
+         <item row="20" column="1">
           <layout class="QHBoxLayout" name="indent_container">
 
            <item>
@@ -1147,14 +1199,14 @@
           </layout>
          </item>
 
-         <item row="20" column="0">
+         <item row="21" column="0">
           <widget class="QLabel" name="label_17">
            <property name="text">
             <string>Presets</string>
            </property>
           </widget>
          </item>
-         <item row="20" column="1">
+         <item row="21" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QComboBox" name="presets"/>
@@ -1230,14 +1282,14 @@
            </item>
           </layout>
          </item>
-         <item row="11" column="0">
+         <item row="12" column="0">
           <widget class="QLabel" name="label_21">
            <property name="text">
             <string>Block Quote Background</string>
            </property>
           </widget>
          </item>
-         <item row="11" column="1">
+         <item row="12" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_6">
            <item>
             <widget class="QLabel" name="quote_preview">
@@ -1374,6 +1426,8 @@
   <tabstop>h2_change_color</tabstop>
   <tabstop>h3_change_font</tabstop>
   <tabstop>h3_change_color</tabstop>
+  <tabstop>bq_change_font</tabstop>
+  <tabstop>bq_change_color</tabstop>
   <tabstop>link_local_change_color</tabstop>
   <tabstop>link_foreign_change_color</tabstop>
   <tabstop>link_cross_change_color</tabstop>

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -344,7 +344,6 @@ bool DocumentStyle::load(QSettings &settings)
 
         background_color = QColor { settings.value("background_color", background_color.name()).toString() };
         blockquote_bgcolor = QColor { settings.value("blockquote_color", blockquote_bgcolor.name()).toString() };
-        blockquote_fgcolor = QColor { settings.value("blockquote_fgcolor", blockquote_fgcolor.name()).toString() };
 
         margin_h = settings.value("margins_h", 30).toInt();
         margin_v = settings.value("margins_v", 55).toInt();
@@ -388,7 +387,7 @@ bool DocumentStyle::load(QSettings &settings)
         {
             settings.beginGroup("Blockquote");
             blockquote_font.fromString(settings.value("font", blockquote_font.toString()).toString());
-            blockquote_fgcolor = QString { settings.value("color", blockquote_fgcolor.name()).toString() };
+            blockquote_fgcolor = QString { settings.value("color", standard_color.name()).toString() };
             settings.endGroup();
         }
         {

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -33,6 +33,7 @@ struct DocumentStyle
     QFont h2_font;
     QFont h3_font;
     QFont preformatted_font;
+    QFont blockquote_font;
 
     QColor background_color;
     QColor standard_color;
@@ -40,7 +41,8 @@ struct DocumentStyle
     QColor h1_color;
     QColor h2_color;
     QColor h3_color;
-    QColor blockquote_color;
+    QColor blockquote_fgcolor;
+    QColor blockquote_bgcolor;
 
     QColor internal_link_color;
     QColor external_link_color;

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -6,6 +6,7 @@
 #include <QList>
 #include <QStringList>
 #include <QDebug>
+#include <QTextTable>
 
 #include "kristall.hpp"
 
@@ -106,20 +107,28 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
             if(line.startsWith(">"))
             {
-                if(not blockquote ) {
-                    // cursor.insertBlock();
+                if(!blockquote)
+                {
+                    // Start blockquote
+                    QTextTable *table = cursor.insertTable(1, 1, text_style.blockquote_tableformat);
+                    cursor.setBlockFormat(text_style.blockquote_format);
+                    QTextTableCell cell = table->cellAt(0, 0);
+                    cell.setFormat(text_style.blockquote);
+                    blockquote = true;
                 }
-                blockquote  = true;
 
-                cursor.setBlockFormat(text_style.block_quote_format);
                 replace_quotes(line);
-                cursor.insertText(trim_whitespace(line.mid(1)) + "\n", text_style.standard);
+                cursor.insertText(trim_whitespace(line.mid(1)) + "\n", text_style.blockquote);
 
                 continue;
             }
             else
             {
-                if(blockquote) {
+                if (blockquote)
+                {
+                    // End blockquote
+                    cursor.deletePreviousChar();
+                    cursor.movePosition(QTextCursor::NextBlock);
                     cursor.setBlockFormat(text_style.standard_format);
                 }
                 blockquote  = false;

--- a/src/renderers/markdownrenderer.cpp
+++ b/src/renderers/markdownrenderer.cpp
@@ -121,7 +121,7 @@ static void renderNode(RenderState &state, cmark_node & node, const QTextCharFor
         state.emitNewBlock();
         state.suppress_next_block = true;
 
-        cursor.setBlockFormat(state.text_style.block_quote_format);
+        cursor.setBlockFormat(state.text_style.blockquote_format);
         renderChildren(state, node, current_format, page_title);
 
         state.emitNewBlock();

--- a/src/renderers/textstyleinstance.cpp
+++ b/src/renderers/textstyleinstance.cpp
@@ -26,10 +26,11 @@ TextStyleInstance::TextStyleInstance(DocumentStyle const & themed_style)
   standard_h3.setFont(themed_style.h3_font);
   standard_h3.setForeground(QBrush(themed_style.h3_color));
 
-  preformatted_format.setNonBreakableLines(true);
+  blockquote.setFont(themed_style.blockquote_font);
+  blockquote.setForeground(QBrush(themed_style.blockquote_fgcolor));
+  blockquote.setBackground(themed_style.blockquote_bgcolor);
 
-  block_quote_format.setIndent(themed_style.indent_bq);
-  block_quote_format.setBackground(themed_style.blockquote_color);
+  preformatted_format.setNonBreakableLines(true);
 
   // Other alignments
   auto align = themed_style.justify_text ? Qt::AlignJustify : Qt::AlignLeft;
@@ -42,9 +43,15 @@ TextStyleInstance::TextStyleInstance(DocumentStyle const & themed_style)
   link_format.setLineHeight(themed_style.line_height_p,
     QTextBlockFormat::LineDistanceHeight);
 
-  block_quote_format.setAlignment(align);
-  block_quote_format.setLineHeight(themed_style.line_height_p,
+  blockquote_format.setAlignment(align);
+  blockquote_format.setLineHeight(themed_style.line_height_p,
     QTextBlockFormat::LineDistanceHeight);
+  blockquote_tableformat.setBorderStyle(QTextFrameFormat::BorderStyle_None);
+  blockquote_tableformat.setHeaderRowCount(0);
+  blockquote_tableformat.setCellPadding(16.0);
+  blockquote_tableformat.setAlignment(Qt::AlignJustify);
+  blockquote_tableformat.setLeftMargin(20.0 * themed_style.indent_bq);
+  blockquote_tableformat.setBottomMargin(20.0);
 
   list_format.setStyle(QTextListFormat::ListDisc);
   list_format.setIndent(themed_style.indent_l);

--- a/src/renderers/textstyleinstance.hpp
+++ b/src/renderers/textstyleinstance.hpp
@@ -16,13 +16,15 @@ struct TextStyleInstance
     QTextCharFormat standard_h1;
     QTextCharFormat standard_h2;
     QTextCharFormat standard_h3;
+    QTextCharFormat blockquote;
 
     QTextBlockFormat standard_format;
     QTextBlockFormat preformatted_format;
-    QTextBlockFormat block_quote_format;
+    QTextBlockFormat blockquote_format;
     QTextBlockFormat heading_format;
     QTextBlockFormat link_format;
     QTextListFormat list_format;
+    QTextTableFormat blockquote_tableformat;
 
     explicit TextStyleInstance(DocumentStyle const & style);
 };


### PR DESCRIPTION
* Configurable font and foreground colour for blockquotes
* Blockquotes now work over multiple lines
* Padding inside of blockquotes (currently hard-coded to 16px).

The padding and multi-line stuff was achieved by making blockquotes act as a "table" with a single row and single column, and applying padding etc from there.

Preview:
![image](https://user-images.githubusercontent.com/42143005/108000828-f1af1a80-703e-11eb-8ae4-6499a06d8f90.png)
