### PR TITLE
Some minor changes

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -1547,7 +1547,7 @@ void BrowserTab::updateMouseCursor(bool waiting)
     if (waiting)
         this->ui->text_browser->setDefaultCursor(Qt::BusyCursor);
     else
-        this->ui->text_browser->setDefaultCursor(Qt::ArrowCursor);
+        this->ui->text_browser->setDefaultCursor(KristallTextBrowser::NORMAL_CURSOR);
 }
 
 bool BrowserTab::enableClientCertificate(const CryptoIdentity &ident)

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -793,7 +793,16 @@ void BrowserTab::updatePageTitle()
 {
     if (page_title.isEmpty())
     {
-        page_title = this->current_location.toString();
+        // Use document filename as title instead.
+        page_title = this->current_location.path();
+        auto parts = page_title.split("/");
+        page_title = parts[parts.length() - 1];
+
+        if (page_title.isEmpty())
+        {
+            // Just use the hostname if we can't find anything else
+            page_title = this->current_location.host();
+        }
     }
 
     // TODO: Shorten lengthy titles?

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -34,6 +34,11 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
     this->ui->ui_theme->addItem(tr("Light"), QVariant::fromValue<int>(int(Theme::light)));
     this->ui->ui_theme->addItem(tr("Dark"), QVariant::fromValue<int>(int(Theme::dark)));
 
+    this->ui->icon_theme->clear();
+    this->ui->icon_theme->addItem(tr("Automatic"), QVariant::fromValue<int>(int(IconTheme::automatic)));
+    this->ui->icon_theme->addItem(tr("Light"), QVariant::fromValue<int>(int(IconTheme::light)));
+    this->ui->icon_theme->addItem(tr("Dark"), QVariant::fromValue<int>(int(IconTheme::dark)));
+
     this->ui->ui_density->clear();
     this->ui->ui_density->addItem(tr("Compact"), QVariant::fromValue<int>(int(UIDensity::compact)));
     this->ui->ui_density->addItem(tr("Classic"), QVariant::fromValue<int>(int(UIDensity::classic)));
@@ -208,6 +213,15 @@ void SettingsDialog::setOptions(const GenericSettings &options)
             break;
         }
     }
+
+    this->ui->icon_theme->setCurrentIndex(0);
+    for(int i = 0; i < this->ui->icon_theme->count(); i++) {
+        if(this->ui->icon_theme->itemData(i).toInt() == int(options.icon_theme)) {
+            this->ui->icon_theme->setCurrentIndex(i);
+            break;
+        }
+    }
+
 
     this->ui->ui_density->setCurrentIndex(0);
     for(int i = 0; i < this->ui->ui_density->count(); ++i) {
@@ -699,6 +713,14 @@ void SettingsDialog::on_ui_theme_currentIndexChanged(int index)
 
     kristall::setTheme(this->current_options.theme);
 }
+
+void SettingsDialog::on_icon_theme_currentIndexChanged(int index)
+{
+    this->current_options.icon_theme = IconTheme(this->ui->icon_theme->itemData(index).toInt());
+
+    kristall::setIconTheme(this->current_options.icon_theme, this->current_options.theme);
+}
+
 
 void SettingsDialog::on_ui_density_currentIndexChanged(int index)
 {

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -120,6 +120,8 @@ private slots:
 
     void on_ui_theme_currentIndexChanged(int index);
 
+    void on_icon_theme_currentIndexChanged(int index);
+
     void on_ui_density_currentIndexChanged(int index);
 
     void on_fancypants_on_clicked();

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -43,52 +43,62 @@
         <widget class="QComboBox" name="ui_theme"/>
        </item>
        <item row="1" column="0">
+        <widget class="QLabel" name="label_34">
+         <property name="text">
+          <string>Icon Theme</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="icon_theme"/>
+       </item>
+       <item row="2" column="0">
         <widget class="QLabel" name="label_1">
          <property name="text">
           <string>UI Density</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QComboBox" name="ui_density"/>
        </item>
 
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_14">
          <property name="text">
           <string>Start Page:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QLineEdit" name="start_page">
          <property name="placeholderText">
           <string>about://blank</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_40">
          <property name="text">
           <string>Search engine:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="search_engine">
          <property name="editable">
           <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>Enabled Protocols</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QCheckBox" name="enable_gemini">
@@ -133,14 +143,14 @@
          </item>
         </layout>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_19">
          <property name="text">
           <string>Text Rendering</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QRadioButton" name="fancypants_on">
@@ -167,14 +177,14 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_18">
          <property name="text">
           <string>Enable text highlights</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QRadioButton" name="texthl_on">
@@ -201,14 +211,14 @@
          </item>
         </layout>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_20">
          <property name="text">
           <string>Gopher Map</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QRadioButton" name="gophermap_icon">
@@ -235,14 +245,14 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_22">
          <property name="text">
           <string>Unknown Scheme</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
           <widget class="QRadioButton" name="scheme_os_default">
@@ -266,14 +276,14 @@
          </item>
         </layout>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_23">
          <property name="text">
           <string>Hidden files in file:// directories</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_8">
          <item>
           <widget class="QRadioButton" name="show_hidden_files">
@@ -297,14 +307,14 @@
          </item>
         </layout>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_24">
          <property name="text">
           <string>URL bar highlights</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
           <widget class="QRadioButton" name="urlbarhl_fancy">
@@ -328,7 +338,7 @@
          </item>
         </layout>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_39">
          <property name="text">
           <string>Use typographer's quotes</string>
@@ -338,7 +348,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_10">
          <item>
           <widget class="QRadioButton" name="fancyquotes_on">
@@ -362,38 +372,38 @@
          </item>
         </layout>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="15" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -406,14 +416,14 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_99">
          <item>
           <widget class="QCheckBox" name="enable_home_btn">
@@ -431,7 +441,7 @@
          </item>
         </layout>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_30">
          <property name="text">
           <string>Total cache size limit</string>
@@ -441,7 +451,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QSpinBox" name="cache_limit">
          <property name="suffix">
           <string> KiB</string>
@@ -455,7 +465,7 @@
         </widget>
        </item>
 
-       <item row="17" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item size threshold</string>
@@ -465,7 +475,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <widget class="QSpinBox" name="cache_threshold">
          <property name="suffix">
           <string> KiB</string>
@@ -479,7 +489,7 @@
         </widget>
        </item>
 
-       <item row="18" column="0">
+       <item row="19" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item life</string>
@@ -489,7 +499,7 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="1">
+       <item row="19" column="1">
         <widget class="QSpinBox" name="cache_life">
          <property name="suffix">
           <string> minutes</string>
@@ -1384,6 +1394,7 @@
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>ui_theme</tabstop>
+  <tabstop>icon_theme</tabstop>
   <tabstop>ui_density</tabstop>
   <tabstop>start_page</tabstop>
   <tabstop>search_engine</tabstop>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -36,6 +36,13 @@ enum class RequestState : int
     StartedWeb = 255,
 };
 
+enum class IconTheme : int
+{
+    automatic = -1,
+    dark = 0,
+    light = 1
+};
+
 struct GenericSettings
 {
     enum TextDisplay {
@@ -53,6 +60,7 @@ struct GenericSettings
     QString start_page = "about:favourites";
     QString search_engine = "gemini://geminispace.info/search?%1";
     Theme theme = Theme::light;
+    IconTheme icon_theme = IconTheme::automatic;
     UIDensity ui_density = UIDensity::compact;
     TextDisplay text_display = FormattedText;
     bool enable_text_decoration = false;
@@ -135,6 +143,8 @@ namespace kristall
     void saveSettings();
 
     void setTheme(Theme theme);
+
+    void setIconTheme(IconTheme icotheme, Theme uitheme);
 
     void setUiDensity(UIDensity density, bool previewing);
 

--- a/src/protocols/geminiclient.cpp
+++ b/src/protocols/geminiclient.cpp
@@ -222,14 +222,14 @@ void GeminiClient::socketReadyRead()
                 switch(primary_code)
                 {
                 case 1: // requesting input
-		    switch (secondary_code) {
-		    case 1:
-		      emit inputRequired(meta, true);
-		      break;
-		    case 0:
-		    default:
-		      emit inputRequired(meta, false);
-		    }
+                    switch (secondary_code) {
+                        case 1:
+                        emit inputRequired(meta, true);
+                        break;
+                        case 0:
+                        default:
+                        emit inputRequired(meta, false);
+                    }
                     return;
 
                 case 2: // success

--- a/src/widgets/kristalltextbrowser.cpp
+++ b/src/widgets/kristalltextbrowser.cpp
@@ -4,6 +4,8 @@
 #include <QScroller>
 #include <QTouchDevice>
 
+const Qt::CursorShape KristallTextBrowser::NORMAL_CURSOR = Qt::IBeamCursor;
+
 KristallTextBrowser::KristallTextBrowser(QWidget *parent) :
     QTextBrowser(parent)
 {

--- a/src/widgets/kristalltextbrowser.hpp
+++ b/src/widgets/kristalltextbrowser.hpp
@@ -27,6 +27,9 @@ private: // slots
 private:
     void updateCursor();
 
+public:
+    static const Qt::CursorShape NORMAL_CURSOR;
+
 private:
     bool signal_new_tab = false;
     QCursor wanted_cursor;


### PR DESCRIPTION
* IBeam cursor is now default. Makes selecting text feel a little more natural
* Tabs that do not have parsable titles in the page now use the document name as the title. Prevents cluttering the tab bar with enormous URLs, etc.
* New 'icon theme' preference: allows the user to override the icon theme if they wish, which is useful for people using the OS Default theme. Also allows users to choose Kristall's light/dark icons instead of the system standard icons if they want. Choices: "Auto", "Light", and "Dark"