### PR TITLE
Root/parent navigation. Tab title changes

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -805,7 +805,11 @@ void BrowserTab::updatePageTitle()
         }
     }
 
-    // TODO: Shorten lengthy titles?
+    // This will strip new-line characters from the title, in case
+    // there are any.
+    static const QRegularExpression NL_REGEX = QRegularExpression("\n");
+    page_title.replace(NL_REGEX, "");
+    page_title = page_title.trimmed();
 
     emit this->titleChanged(this->page_title);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -482,6 +482,35 @@ void MainWindow::on_actionBackward_triggered()
     }
 }
 
+void MainWindow::on_actionRoot_triggered()
+{
+    BrowserTab * tab = this->curTab();
+    if(tab != nullptr && !tab->is_internal_location) {
+        QUrl url = tab->current_location;
+        url.setPath("/");
+        tab->navigateTo(url, BrowserTab::PushImmediate);
+    }
+}
+
+void MainWindow::on_actionParent_triggered()
+{
+    BrowserTab * tab = this->curTab();
+    if(tab != nullptr && !tab->is_internal_location) {
+        QUrl url = tab->current_location;
+
+        // Make sure we have a trailing slash, or else
+        // QUrl::resolved will not work
+        if (!url.path().endsWith("/"))
+        {
+            url.setPath(url.path() + "/");
+        }
+
+        // Go up one directory
+        url = url.resolved(QUrl{".."});
+        tab->navigateTo(url, BrowserTab::PushImmediate);
+    }
+}
+
 void MainWindow::on_actionRefresh_triggered()
 {
     BrowserTab * tab = this->curTab();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -356,19 +356,30 @@ void MainWindow::on_history_view_doubleClicked(const QModelIndex &index)
 
 void MainWindow::on_tab_titleChanged(const QString &title)
 {
-   auto * tab = qobject_cast<BrowserTab*>(sender());
-   if(tab != nullptr) {
-       int index = this->ui->browser_tabs->indexOf(tab);
-       assert(index >= 0);
+    auto * tab = qobject_cast<BrowserTab*>(sender());
+    if(tab != nullptr) {
+        int index = this->ui->browser_tabs->indexOf(tab);
+        assert(index >= 0);
 
-       QString escapedTitle = title;
-       this->ui->browser_tabs->setTabText(index, escapedTitle.replace("&", "&&"));
+        QString escapedTitle = title;
 
-       if (tab == this->curTab())
-       {
+        // Set the window title to full title
+        if (tab == this->curTab())
+        {
             updateWindowTitle();
-       }
-   }
+        }
+
+        // Shorten lengthy titles for tab bar (45 chars max for now - we assume
+        // that Gemini surfers don't usually have loads of tabs open, so the
+        // limit is fairly high)
+        const int MAX_TITLE_LEN = 45;
+        if (escapedTitle.length() > MAX_TITLE_LEN)
+        {
+            escapedTitle = escapedTitle.mid(0, MAX_TITLE_LEN - 3).trimmed() + "...";
+        }
+
+        this->ui->browser_tabs->setTabText(index, escapedTitle.replace("&", "&&"));
+    }
 }
 
 void MainWindow::on_tab_locationChanged(const QUrl &url)

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -70,6 +70,10 @@ private slots:
 
     void on_actionBackward_triggered();
 
+    void on_actionRoot_triggered();
+
+    void on_actionParent_triggered();
+
     void on_actionRefresh_triggered();
 
     void on_actionAbout_Qt_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -320,7 +320,7 @@
     <string>Go to the root directory (/)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+/</string>
+    <string>Alt+/</string>
    </property>
   </action>
   <action name="actionParent">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -222,6 +222,8 @@
     <addaction name="actionGo_to_home"/>
     <addaction name="actionBackward"/>
     <addaction name="actionForward"/>
+    <addaction name="actionRoot"/>
+    <addaction name="actionParent"/>
     <addaction name="separator"/>
     <addaction name="actionRefresh"/>
     <addaction name="separator"/>
@@ -308,6 +310,28 @@
    </property>
    <property name="shortcut">
     <string>Alt+Right</string>
+   </property>
+  </action>
+  <action name="actionRoot">
+   <property name="text">
+    <string>Root</string>
+   </property>
+   <property name="toolTip">
+    <string>Go to the root directory (/)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+/</string>
+   </property>
+  </action>
+  <action name="actionParent">
+   <property name="text">
+    <string>Parent</string>
+   </property>
+   <property name="toolTip">
+    <string>Go to the parent directory</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+Up</string>
    </property>
   </action>
   <action name="actionRefresh">


### PR DESCRIPTION
* Simple 'root' and 'parent' navigation options were added to the menu (idea from gemini://mozz.us/journal/2021-01-01.gmi). Currently bound to Alt+/ and Alt+Up respectively right now, but might be changed. 'Root' navigates to the root directory of the current page, 'parent' navigates to the directory above the current. I think we should add these options to the main user interface somewhere as they are very useful, but I'm not sure where or how we should do it.
* Small bug fix: when visiting some sites (one I came across was https://lists.orbitalfox.eu/archives/gemini/2020/000304.html), the tab title would contain a newline character, which made the tab title look strange; newlines are now stripped from tab titles.
* Tab title is now limited to 45 characters. See 7151494681d5037a6d97b9c6e80ec42308ff2d19 message for more detailed explanation