### PR TITLE
Various changes (unlimited cache option, a fix, and more)

### DIFF
--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -56,6 +56,10 @@ This menu contains means to navigate the internet.
 
 [Foreward] will navigate one page foreward in your history.
 
+[Root] will take you to the root directory of the current site. e.g if you are currently at gemini://example.com/gemlog/some-document.gmi, you will be taken to gemini://example.com/
+
+[Parent] will take you to the 'parent' directory of the current site. e.g if you are at gemini://example.com/parent/some-document.gmi, you will be taken to gemini://example.com/parent/
+
 [Refresh] will reload the current page. This may be necessary for CGI scripts or other interactive content.
 
 [Add to favourites] will add or remove the current page to your list of favourites.
@@ -86,7 +90,9 @@ Kristall offers a vast amount of settings. You can style the documents to your l
 ### Generic
 This tab contains an unsorted list of settings that allow you to tweak Kristalls behaviour.
 
-[UI Theme] controls whether the Qt interface is displayed in a dark or a light theme. You can adjust that to your system style or to your site rendering.
+[UI Theme] controls whether the Qt interface is displayed in a dark or a light theme. You can adjust that to your system style or to your site rendering. The "OS Default" will use your system theme.
+
+[Icon Theme] controls the specific icon set that the Qt interface will use. Usually, the default "Auto" option should be good enough, however for those using the "OS Default" theme, this option may be useful.
 
 [Start Page] is the URL to the page that will be loaded for new tabs. Default is "about:favourites".
 
@@ -112,11 +118,38 @@ gemini://example2.com/search/another/%1
 
 [Unknown Scheme] changes the behaviour how Kristall handles unknown/disabled URL schemes. [Use OS default handler] will invoke your OS default, [Display error message] will just pop up a message box and tell you that Kristall cannot handle this URL.
 
+[Hidden files in file:// directories] determines whether hidden files will display in local directory listings (i.e file:// URLs which do not point to a specific document but rather a directory).
+
+[URL bar highlights] sets whether the URL bar should use "fancy" highlights. The highlighting simply makes the domain of the site more prominent/visible, and the text around it slightly dimmed. This is purely a cosmetic feature.
+
+[Use typographer's quotes] sets whether to replace regular quotation marks, that is:
+```
+"these", and 'these'
+```
+with fancy Unicode quotes, which include the following:
+```
+“these”, and ‘these’
+```
+This is a purely cosmetic feature that may aid in readability.
+
 [Max. Number of Redirections] is a setting that allows you to restrict sites to redirect you only a certain amount of times before erroring out. Setting this to 0 will disable redirections completly, displaying an error with the target URL.
 
 [Redirection Handling] allows you to fine-tune the way Kristall allows redirections. Each of the options defines if Kristall should ask you to allow the redirect or do it silently. [Ask for cross-scheme redirection] will pop up a message box if a host tries to redirect you from one URL scheme to another, e.g. when a web server redirects you from HTTP to HTTPS. [Ask for cross-host redirection] will pop up the message box for all redirections through host boundaries, e.g. when example.com redirects you to www.example.com. [Ask for cross-scheme or cross-host redirection] will enable both of the previous behaviours, asking when any cross-boundary redirection happens. [Ask for all redirections] will pop up a message box every time a server tries to redirect you, keeping you in full control over all redirections. [Silently redirect everything] is the exact oppositve of that, accepting all redirections without warning or notice.
 
 [Network Timeout] is the time a server is allowed to *not respond anything* before a error message appears. As long as a server dripples some bytes to Kristall, no timeout will happen, so having a slow or bad connection shouldn't yield timeouts.
+
+[Additional Toolbar Items] contains various additional toolbar items which some may find useful.
+
+* [Home] button opens the configured home page in the current tab.
+* [New tab] button appears to the right of the tab bar. This simply adds a new tab.
+* [Root] button takes you to the root directory of the current site. (See Menus>Navigation section for explanation of what this does).
+* [Parent] button takes you to the parent directory of the current site. (See Menus>Navigation section for explanation of what this does).
+
+[Total cache size limit] sets the total amount of memory that can be used to cache pages. By default this is set to 500 KiB, but can be set to 0 to completely disable the caching system. The larger this number is, the more memory you are allowing Kristall to use.
+
+[Cached item size threshold] is the maximum size of a single cached item. By default this is set to 400 KiB. This prevents Kristall from caching any pages that are large from clogging up the in-memory cache.
+
+[Cached item life] is the amount of time in minutes before a single cached item is considered "expired." When a cached item is "expired", it is not read from cache, but instead re-retreived from the server. Cache life can be disabled by enabling the [Unlimited item life] option.
 
 ### Style
 On this tab, you can tweak the document rendering in Kristall. On the left half you can see all possible colors and fonts you can tweak, on the right half of the window is a preview rendering with your currently selected style.
@@ -132,7 +165,9 @@ Most items in the *Style* category have either a [Font], [Color] or both buttons
 
 [H2 Font] allows you to change the font and color for secondary headings in documents.
 
-[H3 Font] allows you to change the font and color for ternay headings in documents.
+[H3 Font] allows you to change the font and color for ternary headings in documents.
+
+[Blockquote Font] allows you to change the font and colour for blockquotes in documents.
 
 [Local Link Color] is the color in which links that refer to the same host *and* protocol are rendered.
 
@@ -148,7 +183,28 @@ Most items in the *Style* category have either a [Font], [Color] or both buttons
 
 [Auto-Theme Generation] is an experimental feature that can be set to [Disabled], [Light Theme] and [Dark Theme]. When not set to [Disabled], Kristall will ignore all your beautiful color settings and tries to create a color scheme based on the current pages host name. This allows different styles for each host visited and brings some recognizability in gemini and gopher space.
 
-[Page Margin] is the distance of the page content to the border. Higher values look cooler, but make your display area smaller.
+[Left/right Page Margin] is the distance of horizontal page content to the left/right borders. If you have [Enable text width limit] enabled this value is only used when the window size is less than the set maximum text width.
+
+[Top/bottom Page Margin] is the distance of vertical page content to the top/bottom borders.
+
+[Other options] are a set of extra options to enhance your reading experience (and just look cool in general).
+
+* [Justify text] will make text fill the lines they are on. Note that this only works on gemtext pages.
+
+* [Enable text width limit] will limit the length of text on pages. This works best in gemtext pages, but should also work fine for HTML pages. See below for setting the limit. This can significantly enhance readability of pages.
+
+[Text width limit] sets the maximum line length of text. By default this is set to 900px. If the window itself is smaller in width than the text width limit, the text width limit is "adjusted" to fit inside the window. As mentioned above, horizontal margins will also be applied here.
+
+[Line height (paragraph)] is an additional spacing between paragraph text lines. By default this is set to 5px, and can help with readability. (Gemtext-only feature)
+
+[Line height (header)] is an additional spacing between header text lines. By default this is set to 0px. Pages will usually look better when this is set to a low value, or else headings will appear too far from paragraph text. (Gemtext-only feature)
+
+[Indentation] is a set of options that control the level of indent in certain text parts in Gemini pages.
+
+* [Par] controls indent size of paragraphs (default: 1)
+* [Hea] controls indent size of headings (default: 0)
+* [Quo] controls indent size of blockquotes (default: 2)
+* [Lst] controls indent size of unordered lists (default: 2)
 
 [Presets] is a cool feature to save, restore and share your color themes. The dropdown contains a list of all previously created colors schemes. With the [+] button you can create a scheme with a unique name. The floppy disk button will override the currently selected preset with all the settings displayed above. The folder button will restore a previously saved preset. The last two buttons allow you to import/export presets to disk and share them with your friends! Share all your beautiful color schemes with the world!
 

--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -75,6 +75,10 @@ public:
 
     void navOneForward();
 
+    void navigateToRoot();
+
+    void navigateToParent();
+
     void scrollToAnchor(QString const & anchor);
 
     void reloadPage();
@@ -103,6 +107,8 @@ public:
 
     void updatePageMargins();
 
+    void refreshOptionalToolbarItems();
+
 signals:
     void titleChanged(QString const & title);
     void locationChanged(QUrl const & url);
@@ -119,6 +125,10 @@ private slots:
     void on_url_bar_blurred();
 
     void on_refresh_button_clicked();
+
+    void on_root_button_clicked();
+
+    void on_parent_button_clicked();
 
     void on_fav_button_clicked();
 

--- a/src/browsertab.ui
+++ b/src/browsertab.ui
@@ -112,6 +112,38 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="root_button">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Go the root path of current location</string>
+       </property>
+       <property name="text">
+        <string>/</string>
+       </property>
+       <property name="icon">
+        <iconset theme="go-top"/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="parent_button">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Go the parent path of current location</string>
+       </property>
+       <property name="text">
+        <string>P</string>
+       </property>
+       <property name="icon">
+        <iconset theme="go-up"/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="SearchBar" name="url_bar">
        <property name="placeholderText">
         <string>gemini://</string>

--- a/src/cachehandler.cpp
+++ b/src/cachehandler.cpp
@@ -77,10 +77,14 @@ int CacheHandler::size()
 // Clears expired pages out of cache
 void CacheHandler::clean()
 {
+    // Don't clean anything if we have unlimited item life.
+    if (kristall::options.cache_unlimited_life) return;
+
     // Find list of keys to delete
     std::vector<QString> vec;
     for (auto&& i : this->page_cache)
     {
+        // Check if this cache item is expired.
         if (QDateTime::currentDateTime() > i.second->time_cached
             .addSecs(kristall::options.cache_life * 60))
         {

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -121,7 +121,7 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
     this->ui->enable_justify_text->setChecked(this->current_style.justify_text);
 
     this->ui->enable_text_width->setChecked(this->current_style.text_width_enabled);
-
+    this->ui->text_width->setEnabled(this->current_style.text_width_enabled);
     this->ui->text_width->setValue(this->current_style.text_width);
 
     this->ui->line_height_p->setValue(this->current_style.line_height_p);
@@ -301,6 +301,8 @@ void SettingsDialog::setOptions(const GenericSettings &options)
     this->ui->cache_limit->setValue(this->current_options.cache_limit);
     this->ui->cache_threshold->setValue(this->current_options.cache_threshold);
     this->ui->cache_life->setValue(this->current_options.cache_life);
+    this->ui->enable_unlimited_cache_life->setChecked(this->current_options.cache_unlimited_life);
+    this->ui->cache_life->setEnabled(!this->current_options.cache_unlimited_life);
 }
 
 GenericSettings SettingsDialog::options() const
@@ -836,4 +838,10 @@ void SettingsDialog::on_cache_threshold_valueChanged(int thres)
 void SettingsDialog::on_cache_life_valueChanged(int life)
 {
     this->current_options.cache_life = life;
+}
+
+void SettingsDialog::on_enable_unlimited_cache_life_clicked(bool checked)
+{
+    this->current_options.cache_unlimited_life = checked;
+    this->ui->cache_life->setEnabled(!checked);
 }

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -297,6 +297,8 @@ void SettingsDialog::setOptions(const GenericSettings &options)
 
     this->ui->enable_home_btn->setChecked(this->current_options.enable_home_btn);
     this->ui->enable_newtab_btn->setChecked(this->current_options.enable_newtab_btn);
+    this->ui->enable_root_btn->setChecked(this->current_options.enable_root_btn);
+    this->ui->enable_parent_btn->setChecked(this->current_options.enable_parent_btn);
 
     this->ui->cache_limit->setValue(this->current_options.cache_limit);
     this->ui->cache_threshold->setValue(this->current_options.cache_threshold);
@@ -823,6 +825,16 @@ void SettingsDialog::on_enable_home_btn_clicked(bool checked)
 void SettingsDialog::on_enable_newtab_btn_clicked(bool checked)
 {
     this->current_options.enable_newtab_btn = checked;
+}
+
+void SettingsDialog::on_enable_root_btn_clicked(bool checked)
+{
+    this->current_options.enable_root_btn = checked;
+}
+
+void SettingsDialog::on_enable_parent_btn_clicked(bool checked)
+{
+    this->current_options.enable_parent_btn = checked;
 }
 
 void SettingsDialog::on_cache_limit_valueChanged(int limit)

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -153,6 +153,8 @@ private slots:
 
     void on_enable_home_btn_clicked(bool arg1);
     void on_enable_newtab_btn_clicked(bool arg1);
+    void on_enable_root_btn_clicked(bool arg1);
+    void on_enable_parent_btn_clicked(bool arg1);
 
     void on_cache_limit_valueChanged(int limit);
     void on_cache_threshold_valueChanged(int thres);

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -157,6 +157,7 @@ private slots:
     void on_cache_limit_valueChanged(int limit);
     void on_cache_threshold_valueChanged(int thres);
     void on_cache_life_valueChanged(int life);
+    void on_enable_unlimited_cache_life_clicked(bool checked);
 
 private:
     void reloadStylePreview();

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -433,6 +433,20 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="enable_root_btn">
+           <property name="text">
+            <string>Root (/)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="enable_parent_btn">
+           <property name="text">
+            <string>Parent (..)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="enable_newtab_btn">
            <property name="text">
             <string>New tab</string>
@@ -1436,6 +1450,8 @@
   <tabstop>network_timeout</tabstop>
   <tabstop>enable_home_btn</tabstop>
   <tabstop>enable_newtab_btn</tabstop>
+  <tabstop>enable_root_btn</tabstop>
+  <tabstop>enable_parent_btn</tabstop>
   <tabstop>cache_limit</tabstop>
   <tabstop>cache_threshold</tabstop>
   <tabstop>cache_life</tabstop>

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -500,17 +500,31 @@
         </widget>
        </item>
        <item row="19" column="1">
-        <widget class="QSpinBox" name="cache_life">
-         <property name="suffix">
-          <string> minutes</string>
-         </property>
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>8760</number>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_25">
+         <item>
+          <widget class="QSpinBox" name="cache_life">
+           <property name="suffix">
+            <string> minutes</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>8760</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="enable_unlimited_cache_life">
+           <property name="text">
+            <string>Unlimited item life</string>
+           </property>
+           <property name="toolTip">
+            <string>Sets cached items to be unexpirable. Items will only be removed if the cache is full.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
 
       </layout>
@@ -1425,6 +1439,7 @@
   <tabstop>cache_limit</tabstop>
   <tabstop>cache_threshold</tabstop>
   <tabstop>cache_life</tabstop>
+  <tabstop>enable_unlimited_cache_life</tabstop>
   <tabstop>bg_change_color</tabstop>
   <tabstop>style_preview</tabstop>
   <tabstop>std_change_font</tabstop>

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -433,6 +433,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="enable_newtab_btn">
+           <property name="text">
+            <string>New tab</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="enable_root_btn">
            <property name="text">
             <string>Root (/)</string>
@@ -443,13 +450,6 @@
           <widget class="QCheckBox" name="enable_parent_btn">
            <property name="text">
             <string>Parent (..)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="enable_newtab_btn">
-           <property name="text">
-            <string>New tab</string>
            </property>
           </widget>
          </item>

--- a/src/icons.qrc
+++ b/src/icons.qrc
@@ -21,6 +21,8 @@
         <file>icons/light/actions/edit-delete.svg</file>
         <file>icons/light/actions/go-previous.svg</file>
         <file>icons/light/actions/go-next.svg</file>
+        <file>icons/light/actions/go-up.svg</file>
+        <file>icons/light/actions/go-top.svg</file>
         <file>icons/light/actions/media-playback-pause.svg</file>
         <file>icons/light/actions/media-playback-start.svg</file>
         <file>icons/light/actions/view-refresh.svg</file>
@@ -56,6 +58,8 @@
         <file>icons/dark/actions/edit-delete.svg</file>
         <file>icons/dark/actions/go-previous.svg</file>
         <file>icons/dark/actions/go-next.svg</file>
+        <file>icons/dark/actions/go-up.svg</file>
+        <file>icons/dark/actions/go-top.svg</file>
         <file>icons/dark/actions/media-playback-pause.svg</file>
         <file>icons/dark/actions/media-playback-start.svg</file>
         <file>icons/dark/actions/view-refresh.svg</file>

--- a/src/icons/dark/actions/go-top.svg
+++ b/src/icons/dark/actions/go-top.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m8 20 2 0.8 7-17-2-0.8z" fill="#fff" stroke-width=".8"/>
+</svg>

--- a/src/icons/dark/actions/go-up.svg
+++ b/src/icons/dark/actions/go-up.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m11 20h2v-12l6 6 1-1-8-8-8 8 1 1 6-6z"/><path d="m11 14v-6l-6 6-1-1 8-8 8 8-1 1-6-6v12h-2z" fill="#fff" stroke-width=".03"/><path d="m11 14v-6l-6 6-1-1 8-8 8 8-1 1-6-6v12h-2z" fill="#fff" stroke-width=".03"/></svg>

--- a/src/icons/light/actions/go-top.svg
+++ b/src/icons/light/actions/go-top.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m8 20 2 0.8 7-17-2-0.8z" stroke-width=".8"/>
+</svg>

--- a/src/icons/light/actions/go-up.svg
+++ b/src/icons/light/actions/go-up.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m11 20h2v-12l6 6 1-1-8-8-8 8 1 1 6-6z"/><path d="m11 14v-6l-6 6-1-1 8-8 8 8-1 1-6-6v12h-2z" stroke-width=".03"/><path d="m11 14v-6l-6 6-1-1 8-8 8 8-1 1-6-6v12h-2z" stroke-width=".03"/></svg>

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -80,8 +80,10 @@ struct GenericSettings
     int network_timeout = 5000;
 
     // Additional toolbar items
-    bool enable_home_btn = false;
-    bool enable_newtab_btn = true;
+    bool enable_home_btn = false,
+         enable_newtab_btn = true,
+         enable_root_btn = false,
+         enable_parent_btn = false;
 
     // In-memory caching
     int cache_limit = 1000;

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -86,7 +86,8 @@ struct GenericSettings
     // In-memory caching
     int cache_limit = 1000;
     int cache_threshold = 125;
-    int cache_life = 15;
+    int cache_life = 60;
+    bool cache_unlimited_life = true;
 
     void load(QSettings & settings);
     void save(QSettings & settings) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -384,6 +384,7 @@ void GenericSettings::load(QSettings &settings)
     cache_limit = settings.value("cache_limit", 1000).toInt();
     cache_threshold = settings.value("cache_threshold", 125).toInt();
     cache_life = settings.value("cache_life", 15).toInt();
+    cache_unlimited_life = settings.value("cache_unlimited_life", true).toBool();
 }
 
 void GenericSettings::save(QSettings &settings) const
@@ -429,6 +430,7 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("cache_limit", cache_limit);
     settings.setValue("cache_threshold", cache_threshold);
     settings.setValue("cache_life", cache_life);
+    settings.setValue("cache_unlimited_life", cache_unlimited_life);
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,6 +380,8 @@ void GenericSettings::load(QSettings &settings)
 
     enable_home_btn = settings.value("enable_home_btn", false).toBool();
     enable_newtab_btn = settings.value("enable_newtab_btn", true).toBool();
+    enable_root_btn = settings.value("enable_root_btn", false).toBool();
+    enable_parent_btn = settings.value("enable_parent_btn", false).toBool();
 
     cache_limit = settings.value("cache_limit", 1000).toInt();
     cache_threshold = settings.value("cache_threshold", 125).toInt();
@@ -426,6 +428,8 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("network_timeout", network_timeout);
     settings.setValue("enable_home_btn", enable_home_btn);
     settings.setValue("enable_newtab_btn", enable_newtab_btn);
+    settings.setValue("enable_root_btn", enable_root_btn);
+    settings.setValue("enable_parent_btn", enable_parent_btn);
 
     settings.setValue("cache_limit", cache_limit);
     settings.setValue("cache_threshold", cache_threshold);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -436,7 +436,9 @@ void MainWindow::on_actionSettings_triggered()
     // changes are instantly applied.
     for (int i = 0; i < this->ui->browser_tabs->count(); ++i)
     {
-        this->tabAt(i)->needs_rerender = true;
+        BrowserTab *t = this->tabAt(i);
+        t->refreshOptionalToolbarItems();
+        t->needs_rerender = true;
     }
     // Re-render the currently-open tab if we have one.
     BrowserTab * tab = this->curTab();
@@ -496,29 +498,16 @@ void MainWindow::on_actionBackward_triggered()
 void MainWindow::on_actionRoot_triggered()
 {
     BrowserTab * tab = this->curTab();
-    if(tab != nullptr && !tab->is_internal_location) {
-        QUrl url = tab->current_location;
-        url.setPath("/");
-        tab->navigateTo(url, BrowserTab::PushImmediate);
+    if(tab != nullptr) {
+        tab->navigateToRoot();
     }
 }
 
 void MainWindow::on_actionParent_triggered()
 {
     BrowserTab * tab = this->curTab();
-    if(tab != nullptr && !tab->is_internal_location) {
-        QUrl url = tab->current_location;
-
-        // Make sure we have a trailing slash, or else
-        // QUrl::resolved will not work
-        if (!url.path().endsWith("/"))
-        {
-            url.setPath(url.path() + "/");
-        }
-
-        // Go up one directory
-        url = url.resolved(QUrl{".."});
-        tab->navigateTo(url, BrowserTab::PushImmediate);
+    if(tab != nullptr) {
+        tab->navigateToParent();
     }
 }
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -313,6 +313,9 @@
    </property>
   </action>
   <action name="actionRoot">
+   <property name="icon">
+    <iconset theme="go-top"/>
+   </property>
    <property name="text">
     <string>Root</string>
    </property>
@@ -324,6 +327,9 @@
    </property>
   </action>
   <action name="actionParent">
+   <property name="icon">
+    <iconset theme="go-up"/>
+   </property>
    <property name="text">
     <string>Parent</string>
    </property>

--- a/src/protocols/fingerclient.cpp
+++ b/src/protocols/fingerclient.cpp
@@ -94,5 +94,10 @@ void FingerClient::on_finished()
 
 void FingerClient::on_socketError(QAbstractSocket::SocketError error_code)
 {
+    // Same as GopherClient::on_SocketError. See there for explanation
+    if (error_code == QAbstractSocket::RemoteHostClosedError) {
+        socket.close();
+        return;
+    }
     this->emitNetworkError(error_code, socket.errorString());
 }

--- a/src/protocols/geminiclient.cpp
+++ b/src/protocols/geminiclient.cpp
@@ -391,10 +391,11 @@ void GeminiClient::socketError(QAbstractSocket::SocketError socketError)
     // state and we know the TLS connection has ended.
     if(socketError == QAbstractSocket::RemoteHostClosedError) {
         socket.close();
-    } else {
-        this->is_error_state = true;
-        if(not this->suppress_socket_tls_error) {
-            this->emitNetworkError(socketError, socket.errorString());
-        }
+        return;
+    }
+
+    this->is_error_state = true;
+    if(not this->suppress_socket_tls_error) {
+        this->emitNetworkError(socketError, socket.errorString());
     }
 }

--- a/src/protocols/gopherclient.cpp
+++ b/src/protocols/gopherclient.cpp
@@ -127,8 +127,8 @@ void GopherClient::on_socketError(QAbstractSocket::SocketError error_code)
     // This is more sane then erroring out here as it's a perfectly legal
     // state and we know the connection has ended.
     if (error_code == QAbstractSocket::RemoteHostClosedError) {
+        socket.close();
         return;
-    } else {
-        this->emitNetworkError(error_code, socket.errorString());
     }
+    this->emitNetworkError(error_code, socket.errorString());
 }


### PR DESCRIPTION
* Adds an "unlimited cache item life" option to the settings to disable cache item expiration.
* Applies the fix from #134 for gopher pages to finger pages too, and also fixes the refresh button getting stuck while encountering these errors (socket wasn't being closed).
* Adds new optional 'root' and 'parent' toolbar items. These are disabled by default and were added just to experiment with getting them into the interface. Icons for these have also been created and are used
* Adds some information about many of the new features to the Help document!