### PR TITLE
Text highlight improvements

### DIFF
--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -206,6 +206,8 @@ Most items in the *Style* category have either a [Font], [Color] or both buttons
 * [Quo] controls indent size of blockquotes (default: 1)
 * [Lst] controls indent size of unordered lists (default: 2)
 
+[List item marker] simply lets you set what symbol is used in list items. By default this is set to Filled Circle.
+
 [Presets] is a cool feature to save, restore and share your color themes. The dropdown contains a list of all previously created colors schemes. With the [+] button you can create a scheme with a unique name. The floppy disk button will override the currently selected preset with all the settings displayed above. The folder button will restore a previously saved preset. The last two buttons allow you to import/export presets to disk and share them with your friends! Share all your beautiful color schemes with the world!
 
 The lone text with with the [host.name] text in it can be used to preview some auto-generated themes. It only refreshes the preview and seeds the auto generator with a new host name.

--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -203,7 +203,7 @@ Most items in the *Style* category have either a [Font], [Color] or both buttons
 
 * [Par] controls indent size of paragraphs (default: 1)
 * [Hea] controls indent size of headings (default: 0)
-* [Quo] controls indent size of blockquotes (default: 2)
+* [Quo] controls indent size of blockquotes (default: 1)
 * [Lst] controls indent size of unordered lists (default: 2)
 
 [Presets] is a cool feature to save, restore and share your color themes. The dropdown contains a list of all previously created colors schemes. With the [+] button you can create a scheme with a unique name. The floppy disk button will override the currently selected preset with all the settings displayed above. The folder button will restore a previously saved preset. The last two buttons allow you to import/export presets to disk and share them with your friends! Share all your beautiful color schemes with the world!

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -43,6 +43,11 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
     this->ui->ui_density->addItem(tr("Compact"), QVariant::fromValue<int>(int(UIDensity::compact)));
     this->ui->ui_density->addItem(tr("Classic"), QVariant::fromValue<int>(int(UIDensity::classic)));
 
+    this->ui->list_symbol->clear();
+    this->ui->list_symbol->addItem("Filled circle", QVariant::fromValue<int>(int(QTextListFormat::Style::ListDisc)));
+    this->ui->list_symbol->addItem("Circle", QVariant::fromValue<int>(int(QTextListFormat::Style::ListCircle)));
+    this->ui->list_symbol->addItem("Square", QVariant::fromValue<int>(int(QTextListFormat::Style::ListSquare)));
+
     setGeminiStyle(DocumentStyle { });
 
     this->predefined_styles.clear();
@@ -131,6 +136,14 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
     this->ui->indent_p->setValue(this->current_style.indent_p);
     this->ui->indent_h->setValue(this->current_style.indent_h);
     this->ui->indent_l->setValue(this->current_style.indent_l);
+
+    this->ui->list_symbol->setCurrentIndex(0);
+    for(int i = 0; i < this->ui->list_symbol->count(); ++i) {
+        if(this->ui->list_symbol->itemData(i).toInt() == int(this->current_style.list_symbol)) {
+            this->ui->list_symbol->setCurrentIndex(i);
+            break;
+        }
+    }
 
     auto setFontAndColor = [this](QLabel * label, const QFont &font, QColor color)
     {
@@ -539,6 +552,13 @@ void SettingsDialog::on_indent_l_valueChanged(int value)
     this->reloadStylePreview();
 }
 
+void SettingsDialog::on_list_symbol_currentIndexChanged(int index)
+{
+    if(index >= 0) {
+        current_style.list_symbol = QTextListFormat::Style(this->ui->list_symbol->itemData(index).toInt());
+        reloadStylePreview();
+    }
+}
 
 void SettingsDialog::on_presets_currentIndexChanged(int index)
 {

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -98,6 +98,8 @@ private slots:
     void on_indent_h_valueChanged(int value);
     void on_indent_l_valueChanged(int value);
 
+    void on_list_symbol_currentIndexChanged(int index);
+
     void on_presets_currentIndexChanged(int index);
 
     void on_preset_new_clicked();

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -1238,13 +1238,24 @@
          </item>
 
          <item row="21" column="0">
+          <widget class="QLabel" name="label_41">
+           <property name="text">
+            <string>List item marker</string>
+           </property>
+          </widget>
+         </item>
+         <item row="21" column="1">
+          <widget class="QComboBox" name="list_symbol"/>
+         </item>
+
+         <item row="22" column="0">
           <widget class="QLabel" name="label_17">
            <property name="text">
             <string>Presets</string>
            </property>
           </widget>
          </item>
-         <item row="21" column="1">
+         <item row="22" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QComboBox" name="presets"/>
@@ -1488,6 +1499,7 @@
   <tabstop>indent_h</tabstop>
   <tabstop>indent_bq</tabstop>
   <tabstop>indent_l</tabstop>
+  <tabstop>list_symbol</tabstop>
   <tabstop>presets</tabstop>
   <tabstop>preset_new</tabstop>
   <tabstop>preset_save</tabstop>

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -147,7 +147,8 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     text_width_enabled(true),
     line_height_p(5.0),
     line_height_h(0.0),
-    indent_bq(1), indent_p(1), indent_h(0), indent_l(2)
+    indent_bq(1), indent_p(1), indent_h(0), indent_l(2),
+    list_symbol(QTextListFormat::ListDisc)
 {
     if (do_init) this->initialiseDefaultFonts();
 }
@@ -298,6 +299,7 @@ bool DocumentStyle::save(QSettings &settings) const
         settings.setValue("indent_p", indent_p);
         settings.setValue("indent_h", indent_h);
         settings.setValue("indent_l", indent_l);
+        settings.setValue("list_symbol", (int)list_symbol);
 
         settings.endGroup();
     }
@@ -414,6 +416,7 @@ bool DocumentStyle::load(QSettings &settings)
             indent_p = settings.value("indent_p", indent_p).toInt();
             indent_h = settings.value("indent_h", indent_h).toInt();
             indent_l = settings.value("indent_l", indent_l).toInt();
+            list_symbol = (QTextListFormat::Style)settings.value("list_symbol", list_symbol).toInt();
 
             settings.endGroup();
         }

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -317,7 +317,7 @@ bool DocumentStyle::load(QSettings &settings)
             h2_font.fromString(settings.value("h2_font").toString());
             h3_font.fromString(settings.value("h3_font").toString());
             preformatted_font.fromString(settings.value("preformatted_font").toString());
-            blockquote_font.fromString(settings.value("blockquote_font").toString());
+            blockquote_font.fromString(settings.value("standard_font").toString());
 
             background_color = QColor(settings.value("background_color").toString());
             standard_color = QColor(settings.value("standard_color").toString());
@@ -386,7 +386,7 @@ bool DocumentStyle::load(QSettings &settings)
         }
         {
             settings.beginGroup("Blockquote");
-            blockquote_font.fromString(settings.value("font", blockquote_font.toString()).toString());
+            blockquote_font.fromString(settings.value("font", standard_font.toString()).toString());
             blockquote_fgcolor = QString { settings.value("color", standard_color.name()).toString() };
             settings.endGroup();
         }

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -147,7 +147,7 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     text_width_enabled(true),
     line_height_p(5.0),
     line_height_h(0.0),
-    indent_bq(2), indent_p(1), indent_h(0), indent_l(2)
+    indent_bq(1), indent_p(1), indent_h(0), indent_l(2)
 {
     if (do_init) this->initialiseDefaultFonts();
 }

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -5,6 +5,7 @@
 #include <QFont>
 #include <QColor>
 #include <QSettings>
+#include <QTextListFormat>
 
 struct DocumentStyle
 {
@@ -61,6 +62,7 @@ struct DocumentStyle
     double line_height_p;
     double line_height_h;
     int indent_bq, indent_p, indent_h, indent_l;
+    QTextListFormat::Style list_symbol;
 
     bool save(QSettings & settings) const;
     bool load(QSettings & settings);

--- a/src/renderers/textstyleinstance.cpp
+++ b/src/renderers/textstyleinstance.cpp
@@ -53,7 +53,7 @@ TextStyleInstance::TextStyleInstance(DocumentStyle const & themed_style)
   blockquote_tableformat.setLeftMargin(20.0 * themed_style.indent_bq);
   blockquote_tableformat.setBottomMargin(20.0);
 
-  list_format.setStyle(QTextListFormat::ListDisc);
+  list_format.setStyle(themed_style.list_symbol);
   list_format.setIndent(themed_style.indent_l);
 
   preformatted_format.setIndent(themed_style.indent_p);


### PR DESCRIPTION
The "experimental text highlights" have now been totally re-written. The implementation is a little ugly and somewhat lengthy, but it seems to work well in all the cases that I tested it in (haven't found any issues/bugs with it yet). I designed the implementation in such a way that should preserve any deliberate usage of the underscore or asterisk in text. So for example if someone where to have a something like_this, or like*this, Kristall would not change it. For kristall to make something bold or underscored, it needs to look something like this:
```
This **will be bold**
This *will be bold*, this will be _underlined_
```
But the following will not be changed:
```
This will not*be*bold
This will not_be_underlined
```
As you can see:
![image](https://user-images.githubusercontent.com/42143005/108590532-252fd300-73b8-11eb-9f36-420fbbf2aa34.png)

This will also close #141 

Other small changes:
* Default blockquote font is the same as the "standard" font" - this helps when migrating from older themes
* There's now a new preference to adjust the "list symbol" (can choose between disc, circle, square) in per-theme settings.