### PR TITLE
Makefile: remove MAKEFLAGS parameter from sub-make calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ kristall: build/kristall
 .PHONY: build/kristall
 build/kristall: src/*
 	mkdir -p build
-	cd build; $(HOMEBREW_PATH) $(QMAKE_COMMAND) CONFIG+=$(QMAKE_CONFIG) ../src/kristall.pro && $(MAKE) $(MAKEFLAGS)
+	cd build; $(HOMEBREW_PATH) $(QMAKE_COMMAND) CONFIG+=$(QMAKE_CONFIG) ../src/kristall.pro && $(MAKE)
 install: kristall
 	# Prepare directories
 	$(MAKEDIR) $(sharedir)/icons/hicolor/scalable/apps/


### PR DESCRIPTION
This broke running make with flags like -k or -s set, because make apparently removes hyphens from those flags, making it to think that we want to run a not existing target.

Also, flags are stored in env, so child processes know which flags are in use and we don't have to provide them again.