### PR TITLE
Add 'indent size' option

### DIFF
--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -206,6 +206,8 @@ Most items in the *Style* category have either a [Font], [Color] or both buttons
 * [Quo] controls indent size of blockquotes (default: 1)
 * [Lst] controls indent size of unordered lists (default: 2)
 
+[Indent Size] is the size in pixels of a single indent. This affects how much of an effect the above [Indentation] settings have on the layout (default 15).
+
 [List item marker] simply lets you set what symbol is used in list items. By default this is set to Filled Circle.
 
 [Presets] is a cool feature to save, restore and share your color themes. The dropdown contains a list of all previously created colors schemes. With the [+] button you can create a scheme with a unique name. The floppy disk button will override the currently selected preset with all the settings displayed above. The folder button will restore a previously saved preset. The last two buttons allow you to import/export presets to disk and share them with your friends! Share all your beautiful color schemes with the world!
@@ -267,7 +269,7 @@ This dialog provides means to create a new persistent identity.
 [Group] is the name of the group where this certificate should be stored. You can either chose an existing group from the drop down or just enter a non-existing name to create a new group ad-hoc.
 [Display Name] is the title of the certificate that Kristall will show you. It will not be sent to a server ever.
 [Common Name] is the CN field in the X509 certificate. It's required for identitication to the hosts.
-[Exporation Date] is the date when your certificate becomes invalid. Kristall choses a default of "1 year from now on", but you can chose any time you want, even just 30 minutes. Better chose a long time though if you don't know how long you need that certificate.
+[Expiration Date] is the date when your certificate becomes invalid. Kristall choses a default of "1 year from now on", but you can chose any time you want, even just 30 minutes. Better chose a long time though if you don't know how long you need that certificate.
 
 With a click on [OK], Kristall will create a new certificate and put it in your certificate store. It can then be selected from the certificate selection dialog or certificate manager.
 
@@ -287,8 +289,12 @@ This list contains all built-in shortcuts:
 * Ctrl+L ⇒ Focus URL bar
 * Ctrl+S ⇒ Save current file
 * Ctrl+H ⇒ Go to home page
+* Ctrl+U ⇒ View document source
 * Alt+Left ⇒ Navigate one page back
 * Alt+Right ⇒ Navigate one page forward
+* Alt+Up ⇒ Navigate to parent directory
+* Alt+/ ⇒ Navigate to root directory
+* Alt+, ⇒ Open Settings dialog
 * F1 ⇒ View this document
 * F5 ⇒ Refresh current tab
 

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -136,6 +136,7 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
     this->ui->indent_p->setValue(this->current_style.indent_p);
     this->ui->indent_h->setValue(this->current_style.indent_h);
     this->ui->indent_l->setValue(this->current_style.indent_l);
+    this->ui->indent_size->setValue(this->current_style.indent_size);
 
     this->ui->list_symbol->setCurrentIndex(0);
     for(int i = 0; i < this->ui->list_symbol->count(); ++i) {
@@ -549,6 +550,12 @@ void SettingsDialog::on_indent_p_valueChanged(int value)
 void SettingsDialog::on_indent_l_valueChanged(int value)
 {
     this->current_style.indent_l = value;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_indent_size_valueChanged(double value)
+{
+    this->current_style.indent_size = value;
     this->reloadStylePreview();
 }
 

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -98,6 +98,8 @@ private slots:
     void on_indent_h_valueChanged(int value);
     void on_indent_l_valueChanged(int value);
 
+    void on_indent_size_valueChanged(double value);
+
     void on_list_symbol_currentIndexChanged(int index);
 
     void on_presets_currentIndexChanged(int index);

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -1238,24 +1238,45 @@
          </item>
 
          <item row="21" column="0">
+          <widget class="QLabel" name="label_42">
+           <property name="text">
+            <string>Indent size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="21" column="1">
+          <widget class="QDoubleSpinBox" name="indent_size">
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <double>100</double>
+           </property>
+          </widget>
+         </item>
+
+         <item row="22" column="0">
           <widget class="QLabel" name="label_41">
            <property name="text">
             <string>List item marker</string>
            </property>
           </widget>
          </item>
-         <item row="21" column="1">
+         <item row="22" column="1">
           <widget class="QComboBox" name="list_symbol"/>
          </item>
 
-         <item row="22" column="0">
+         <item row="23" column="0">
           <widget class="QLabel" name="label_17">
            <property name="text">
             <string>Presets</string>
            </property>
           </widget>
          </item>
-         <item row="22" column="1">
+         <item row="23" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QComboBox" name="presets"/>

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -148,6 +148,7 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
     line_height_p(5.0),
     line_height_h(0.0),
     indent_bq(1), indent_p(1), indent_h(0), indent_l(2),
+    indent_size(15.0),
     list_symbol(QTextListFormat::ListDisc)
 {
     if (do_init) this->initialiseDefaultFonts();
@@ -299,6 +300,7 @@ bool DocumentStyle::save(QSettings &settings) const
         settings.setValue("indent_p", indent_p);
         settings.setValue("indent_h", indent_h);
         settings.setValue("indent_l", indent_l);
+        settings.setValue("indent_size", indent_size);
         settings.setValue("list_symbol", (int)list_symbol);
 
         settings.endGroup();
@@ -416,6 +418,7 @@ bool DocumentStyle::load(QSettings &settings)
             indent_p = settings.value("indent_p", indent_p).toInt();
             indent_h = settings.value("indent_h", indent_h).toInt();
             indent_l = settings.value("indent_l", indent_l).toInt();
+            indent_size = settings.value("indent_size", indent_size).toDouble();
             list_symbol = (QTextListFormat::Style)settings.value("list_symbol", list_symbol).toInt();
 
             settings.endGroup();

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -62,6 +62,7 @@ struct DocumentStyle
     double line_height_p;
     double line_height_h;
     int indent_bq, indent_p, indent_h, indent_l;
+    int indent_size;
     QTextListFormat::Style list_symbol;
 
     bool save(QSettings & settings) const;

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
     std::unique_ptr<GeminiDocument> result = std::make_unique<GeminiDocument>();
     renderhelpers::setPageMargins(result.get(), themed_style.margin_h, themed_style.margin_v);
-    result->setIndentWidth(20);
+    result->setIndentWidth(themed_style.indent_size);
 
     bool emit_fancy_text = kristall::options.enable_text_decoration;
 

--- a/src/renderers/markdownrenderer.cpp
+++ b/src/renderers/markdownrenderer.cpp
@@ -319,7 +319,7 @@ std::unique_ptr<QTextDocument> MarkdownRenderer::render(
 
     auto doc = std::make_unique<QTextDocument>();
     renderhelpers::setPageMargins(doc.get(), style.margin_h, style.margin_v);
-    doc->setIndentWidth(20);
+    doc->setIndentWidth(style.indent_size);
 
     outline.beginBuild();
 

--- a/src/renderers/textstyleinstance.cpp
+++ b/src/renderers/textstyleinstance.cpp
@@ -50,7 +50,9 @@ TextStyleInstance::TextStyleInstance(DocumentStyle const & themed_style)
   blockquote_tableformat.setHeaderRowCount(0);
   blockquote_tableformat.setCellPadding(16.0);
   blockquote_tableformat.setAlignment(Qt::AlignJustify);
-  blockquote_tableformat.setLeftMargin(20.0 * themed_style.indent_bq);
+
+  // We set blockquote indent manually, since it is a table.
+  blockquote_tableformat.setLeftMargin(themed_style.indent_size * themed_style.indent_bq);
   blockquote_tableformat.setBottomMargin(20.0);
 
   list_format.setStyle(themed_style.list_symbol);


### PR DESCRIPTION
This adds an option to fine-tune the indentation amounts - which helps when using smaller fonts. By default the indent amount is 15px

Also adds an entry to the Help page, along with documentation of added shortcuts