### PR TITLE
Check if dpkg-buildflags is present and append flags in qmake for hardening purposes

### DIFF
--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -21,6 +21,14 @@ DEFINES += KRISTALL_VERSION="\"$(shell cd $$PWD; git describe --tags)\""
 # We need iconv on non-linux platforms
 !linux: LIBS += -liconv
 
+# On systems that have dpkg, append build flags for hardening
+system("which dpkg-buildflags") {
+    QMAKE_CPPFLAGS *= $(shell dpkg-buildflags --get CPPFLAGS)
+    QMAKE_CFLAGS   *= $(shell dpkg-buildflags --get CFLAGS)
+    QMAKE_CXXFLAGS *= $(shell dpkg-buildflags --get CXXFLAGS)
+    QMAKE_LFLAGS   *= $(shell dpkg-buildflags --get LDFLAGS)
+}
+
 QMAKE_CFLAGS += -Wno-unused-parameter -Werror=return-type
 QMAKE_CXXFLAGS += -Wno-unused-parameter -Werror=return-type
 

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -21,12 +21,14 @@ DEFINES += KRISTALL_VERSION="\"$(shell cd $$PWD; git describe --tags)\""
 # We need iconv on non-linux platforms
 !linux: LIBS += -liconv
 
-# On systems that have dpkg, append build flags for hardening
-system("which dpkg-buildflags") {
-    QMAKE_CPPFLAGS *= $(shell dpkg-buildflags --get CPPFLAGS)
-    QMAKE_CFLAGS   *= $(shell dpkg-buildflags --get CFLAGS)
-    QMAKE_CXXFLAGS *= $(shell dpkg-buildflags --get CXXFLAGS)
-    QMAKE_LFLAGS   *= $(shell dpkg-buildflags --get LDFLAGS)
+# On linux systems that have dpkg, append build flags for hardening
+linux {
+    system("which dpkg-buildflags") {
+        QMAKE_CPPFLAGS *= $(shell dpkg-buildflags --get CPPFLAGS)
+        QMAKE_CFLAGS   *= $(shell dpkg-buildflags --get CFLAGS)
+        QMAKE_CXXFLAGS *= $(shell dpkg-buildflags --get CXXFLAGS)
+        QMAKE_LFLAGS   *= $(shell dpkg-buildflags --get LDFLAGS)
+    }
 }
 
 QMAKE_CFLAGS += -Wno-unused-parameter -Werror=return-type


### PR DESCRIPTION
As discussed in #156, appends dpkg-buildflags in qmake. As pointed by @MasterQ32, I tried to not assume that the system has dpkg installed with the `system` function.

It occurred to me now that I'm assuming `which` is installed, but it may not be true on mac and windows (although I think the call to `which` will fail and in consequence the `system` function will just assume a normal failure). So do you think it's necessary to include the `unix { }` declaration (or any other feedback on this PR)?