### PR TITLE
KristallTextBrowser: touch scroll fix

### DIFF
--- a/src/widgets/kristalltextbrowser.cpp
+++ b/src/widgets/kristalltextbrowser.cpp
@@ -15,11 +15,15 @@ KristallTextBrowser::KristallTextBrowser(QWidget *parent) :
 {
     connect(this, &QTextBrowser::anchorClicked, this, &KristallTextBrowser::on_anchorClicked);
 
-    // Enable touch scrolling
-    if (QTouchDevice::devices().length() > 0)
+    // Enable touch scrolling on touchscreen devices
+    for (int i = 0; i < QTouchDevice::devices().length(); ++i)
     {
-        this->viewport()->setAttribute(Qt::WA_AcceptTouchEvents);
-        QScroller::grabGesture(this, QScroller::LeftMouseButtonGesture);
+        if (QTouchDevice::devices()[i]->type() == QTouchDevice::TouchScreen)
+        {
+            this->viewport()->setAttribute(Qt::WA_AcceptTouchEvents);
+            QScroller::grabGesture(this, QScroller::LeftMouseButtonGesture);
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
I was testing kristall on a laptop and noticed that the touch-scrolling feature (since #121) for touch-screen devices also caused devices with touch**pads** to act as if touch scrolling was enabled. 

This causes an annoying bug, where you can click to scroll the page using the mouse, as if the mouse were a finger on a touch screen.

This patch ensures that touch scrolling is only enabled on TouchScreen devices specifically, so the issue no longer occurs with touchpad devices 😉