### PR TITLE
DocumentStyle: potential fixes for font issues

### DIFF
--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -24,11 +24,6 @@ struct DocumentStyle
 
     Theme theme;
 
-    //! This is only a runtime value that is used to create
-    //! unique font names in `derive()`.
-    //! This is a terrible hack
-    QString cookie;
-
     QFont standard_font;
     QFont h1_font;
     QFont h2_font;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,8 +97,15 @@ int main(int argc, char *argv[])
 
     {
         // Initialise default fonts
+    #ifdef Q_OS_WIN32
+        // Windows default fonts are ugly, so we use standard ones.
+        kristall::default_font_family = "Segoe UI";
+        kristall::default_font_family_fixed = "Consolas";
+    #else
+        // *nix
         kristall::default_font_family = QFontDatabase::systemFont(QFontDatabase::GeneralFont).family();
         kristall::default_font_family_fixed = QFontInfo(QFont("monospace")).family();
+    #endif
         kristall::document_style.initialiseDefaultFonts();
     }
 


### PR DESCRIPTION
This commit should hopefully fix all the font problems we were having. Instead of using font substitution for emojis, we just instead call QFont::setFamilies. Builds with Qt versions below 5.13 will not have proper emoji support - I don't think this should be too much of an issue really

Notable changes:

* emojis seem to work fine at least in my environment
* when selecting a theme (e.g the presets) with font that is not on the system, a respectable default is used instead. 
* Changing fonts from the settings now always works. Previously the fonts would sometimes be "stuck" and changes didn't take affect until re-launching kristall
* a "fallback" font (set to the default font) is added and has higher preference than the emoji fonts, and lower preference than the actual main text font. This prevents the issue shown here: https://github.com/MasterQ32/kristall/issues/166#issuecomment-784498588
* configured fonts now work fine on Windows (seems to be due to the removal of insertSubstitutions, which didn't seem to work on Windows at least in my environment)
* the dodgey 'Kristall XX' substitution stuff was removed, as it shouldn't be needed if this patch works

This should also close #116 