### PR TITLE
Man page documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 build/
 kristall
+doc/kristall.1
 
 *~
 *.autosave
@@ -121,7 +122,7 @@ target_wrapper.*
 # QtCreator CMake
 CMakeLists.txt.user*
 
-# QtCreator 4.8< compilation database 
+# QtCreator 4.8< compilation database
 compile_commands.json
 
 # QtCreator local machine specific files for imported projects

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Install to /usr/local unless otherwise specified, such as `make PREFIX=/app`
 PREFIX?=/usr/local
 
+# Man pages by default instaled to /usr/share/man, like above this can
+# be specified on command line.
+MANPATH?=/usr/share/man
+
 # What to run to install various files
 INSTALL?=install
 # Run to install the actual binary
@@ -11,6 +15,7 @@ INSTALL_DATA=$(INSTALL) -m 644
 # Directories into which to install the various files
 bindir=$(DESTDIR)$(PREFIX)/bin
 sharedir=$(DESTDIR)$(PREFIX)/share
+mandir=$(DESTDIR)$(MANPATH)/man1
 MAKEDIR=mkdir -p
 
 # Default Qmake Command For Ubuntu (and probably other Debian) distributions
@@ -32,6 +37,8 @@ kristall: build/kristall
 build/kristall: src/*
 	mkdir -p build
 	cd build; $(HOMEBREW_PATH) $(QMAKE_COMMAND) CONFIG+=$(QMAKE_CONFIG) ../src/kristall.pro && $(MAKE)
+	cd doc; ./gen-man.sh
+
 install: kristall
 	# Prepare directories
 	$(MAKEDIR) $(sharedir)/icons/hicolor/scalable/apps/
@@ -42,7 +49,7 @@ install: kristall
 	$(MAKEDIR) $(sharedir)/applications/
 	$(MAKEDIR) $(sharedir)/mime/packages/
 	$(MAKEDIR) $(bindir)
-  
+
 	# Install files
 	$(INSTALL_DATA) src/icons/kristall.svg $(sharedir)/icons/hicolor/scalable/apps/net.random-projects.kristall.svg
 	$(INSTALL_DATA) src/icons/kristall-16.png $(sharedir)/icons/hicolor/16x16/apps/net.random-projects.kristall.png
@@ -51,6 +58,7 @@ install: kristall
 	$(INSTALL_DATA) src/icons/kristall-128.png $(sharedir)/icons/hicolor/128x128/apps/net.random-projects.kristall.png
 	$(INSTALL_DATA) Kristall.desktop $(sharedir)/applications/Kristall.desktop
 	$(INSTALL_DATA) kristall-mime-info.xml $(sharedir)/mime/packages/kristall.xml
+	$(INSTALL_DATA) doc/kristall.1 $(mandir)/kristall.1
 	$(INSTALL_PROGRAM) kristall $(bindir)/kristall
 
 uninstall:
@@ -61,6 +69,8 @@ uninstall:
 	rm -f $(sharedir)/icons/hicolor/*x*/apps/net.random-projects.kristall.png
 	# Remove the binary
 	rm -f $(bindir)/kristall
+	# Remove man page
+	rm -f $(mandir)/kristall.1
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Install to /usr/local unless otherwise specified, such as `make PREFIX=/app`
 PREFIX?=/usr/local
 
-# Man pages by default instaled to /usr/share/man, like above this can
+# Man pages by default instaled to /usr/local/share/man, like above this can
 # be specified on command line.
-MANPATH?=/usr/share/man
+MANPATH?=$(PREFIX)/share/man
 
 # What to run to install various files
 INSTALL?=install

--- a/doc/gem-to-man.awk
+++ b/doc/gem-to-man.awk
@@ -1,0 +1,83 @@
+#!/bin/awk -f
+
+BEGIN {
+    preformatted=0
+}
+
+# Empty lines
+/^$/ {
+    print "."
+    next
+}
+
+# Level 2 headings become section headings.
+/^##\s/ {
+    print ".SH"
+    sub(/^##\s/, "")
+    print toupper($0)
+    next
+}
+
+# Level 3 headings become subsection headings.
+/^###\s/ {
+    sub(/^###\s/, "")
+    print ".SS \"" $0 "\""
+    next
+}
+
+# Lists
+/^\*\s/ {
+    print ".IP \\(bu 3"
+    sub(/^\*\s/, "")
+    print
+    next
+}
+
+# Preformatted text
+/^```/ {
+    # We simply place indent macros to make
+    # it stand out a little.
+    if (!preformatted)
+    {
+        print ".RS"
+        preformatted=1
+    }
+    else
+    {
+        preformatted=0
+        print ".RE"
+    }
+    next
+}
+
+# Links
+/^=>/ {
+    # Strips => prefix, and separates URL and link
+    # title.
+    sub(/^=>/, "")
+    url=$1
+    $1=""
+    title=$0
+
+    print ".IP"
+
+    # Print either URL on its own or Title: URL if we
+    # have a title.
+    if (title == "")
+    {
+        print url
+    }
+    else
+    {
+        gsub(/^\s/, "", title)
+        print title ": " url
+    }
+
+    next
+}
+
+# Paragraphs (default)
+{
+    print ".PP"
+    print
+}

--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -54,8 +54,8 @@ gem_in=$(
     cat "$gemtext_in" |
 
     # Strip a few lines from beginning/end of file.
-    tail -n +7 |
-    head -n -7 |
+    tail -n +9 |
+    head -n -9 |
 
     # First expression replaces all [Text like this] with bold text.
     # Second expression replaces text like *This* or _this_ with italic text.

--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# gen-man
+#
+# Generates kristall's man page from the gemtext about:help file.
+#
+# How we do this:
+# 0.) We insert a pre-defined "head" first, which contains flags, options, etc
+#     which are not present in the Help file.
+#
+# 1.) Convert the main stuff the Help file to a roff format.
+#
+# 2.) Append a pre-defined "tail".
+
+# Locations of the "head" and "tail"
+man_head="./kristall-head.man"
+man_tail="./kristall-tail.man"
+man_output="./kristall.1"
+gemtext_in="../src/about/help.gemini"
+
+main() {
+    # Make sure we have all the stuff we need
+    if [[ ! -f "$man_head" ]]; then
+        echo "man page head does not exist."
+        exit -1
+    fi
+    if [[ ! -f "$man_tail" ]]; then
+        echo "man page tail does not exist"
+        exit -1
+    fi
+    if [[ -z "$man_output" ]]; then
+        echo "No output file"
+        exit -1
+    fi
+    if [[ ! -f "$gemtext_in" ]]; then
+        echo "Input gemtext file does not exist"
+        exit -1
+    fi
+
+    # Write the head to the output file.
+    cp "$man_head" "$man_output"
+
+    # Insert last modified date (use last-modified date of help.gemini)
+    last_modified=$(date -r "$gemtext_in" +"%Y-%M-%d")
+    sed -i "$man_output" -e 's#\$(DATE)#'"$last_modified"'#g'
+
+    # Convert gemtext about page to roff's man format:
+    convert_gemtext "$gemtext_in" >> "$man_output"
+
+    # Write the tail to the output file.
+    cat "$man_tail" >> "$man_output"
+}
+
+# Simple converter for gemtext to roff
+# Note that this is not a converter of "standard" gemtext, and is
+# designed specifically for kristall's about page. Thus, this may not work
+# as expected on other gemtext files (may require a little tweaking)
+convert_gemtext() {
+    gem_in="$(cat $1 | tail -n +7 | head -n -7)"
+
+    # Replace [Text] with bold text.
+    gem_in="$(echo "$gem_in" | sed -Ee 's#\[([^]]*)\]#\\fB\1\\fR#g')"
+
+    # Replace *Text* or _text_ with italic (not bold to help differentiate with the above)
+    # (Regex is derived from one in geminirenderer.cpp)
+    gem_in="$(echo "$gem_in" | sed -Ee 's#(^|[.,!? ]+)[*_]([^*_ ]+[^*_]+[^*_ ]+)[*_]($|[.,!? ])#\1\\fI\2\\fR\3#g')"
+
+    is_preformatted=false
+
+    # Iterate over all the lines in the gemtext file
+    while IFS= read -r line; do
+        if echo "$line" | grep -q '^##\s'; then
+            # Top level heading
+            text="${line#'## '}"
+            echo ".SH"
+            echo "${text^^}"
+        elif echo "$line" | grep -q '^###\s'; then
+            # Level 2 heading
+            text="${line#'### '}"
+            echo ".SS"
+            echo "$text"
+        elif echo "$line" | grep -q '^\*\s'; then
+            # Lists
+            text="${line#'* '}"
+            echo ".IP \(bu 3"
+            echo "${text}"
+        elif echo "$line" | grep -q '^\=>'; then
+            # Links. We only show the URL itself if there is one.
+            text="${line#'=>'}"
+            title="$(echo "$text" | awk '{$1=""; print $0}')"
+            text="$(echo "$text" | awk '{print $1}')"
+
+            # Prefix with URL title if we have one
+            if [[ -n "$title" ]]; then
+                text="$title: $text"
+            fi
+
+            echo ".IP"
+
+            # Echo the text, we also strip leading whitespace
+            echo "$text" | sed -e 's#^[[:space:]]*##'
+        elif echo "$line" | grep -q '^```'; then
+            # Preformatted text. We just indent it
+            if [[ "$is_preformatted" = false ]]; then
+                echo ".RS"
+                is_preformatted=true
+            else
+                echo ".RE"
+                is_preformatted=false
+            fi
+        elif [[ -z "$line" ]]; then
+            # Empty lines
+            echo "."
+        else
+            # Regular paragraphs
+            echo ".PP"
+            echo "$line"
+        fi
+    done <<< "$gem_in"
+}
+
+main "$@"

--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -17,106 +17,55 @@ man_head="./kristall-head.man"
 man_tail="./kristall-tail.man"
 man_output="./kristall.1"
 gemtext_in="../src/about/help.gemini"
+gemtext_converter="./gem-to-man.awk"
 
-main() {
-    # Make sure we have all the stuff we need
-    if [[ ! -f "$man_head" ]]; then
-        echo "man page head does not exist."
-        exit -1
-    fi
-    if [[ ! -f "$man_tail" ]]; then
-        echo "man page tail does not exist"
-        exit -1
-    fi
-    if [[ -z "$man_output" ]]; then
-        echo "No output file"
-        exit -1
-    fi
-    if [[ ! -f "$gemtext_in" ]]; then
-        echo "Input gemtext file does not exist"
-        exit -1
-    fi
+# Make sure we have all the stuff we need
+if [[ ! -f "$man_head" ]]; then
+    echo "man page head does not exist."
+    exit -1
+fi
+if [[ ! -f "$man_tail" ]]; then
+    echo "man page tail does not exist"
+    exit -1
+fi
+if [[ -z "$man_output" ]]; then
+    echo "No output file"
+    exit -1
+fi
+if [[ ! -f "$gemtext_in" ]]; then
+    echo "Input gemtext file does not exist"
+    exit -1
+fi
+if [[ ! -f "$gemtext_converter" ]]; then
+    echo "Gemtext converter script does not exist"
+    exit -1
+fi
 
-    # Write the head to the output file.
-    cp "$man_head" "$man_output"
+# Write the head to the output file.
+cp "$man_head" "$man_output"
 
-    # Insert last modified date (use last-modified date of help.gemini)
-    last_modified=$(date -r "$gemtext_in" +"%Y-%M-%d")
-    sed -i "$man_output" -e 's#\$(DATE)#'"$last_modified"'#g'
+# Insert last modified date (use last-modified date of help.gemini)
+last_modified=$(date -r "$gemtext_in" +"%Y-%M-%d")
+sed -i "$man_output" -e 's#\$(DATE)#'"$last_modified"'#g'
 
-    # Convert gemtext about page to roff's man format:
-    convert_gemtext "$gemtext_in" >> "$man_output"
+# Some pre-processing before giving our gemtext to the awk script.
+gem_in=$(
+    # Read input file
+    cat "$gemtext_in" |
 
-    # Write the tail to the output file.
-    cat "$man_tail" >> "$man_output"
-}
+    # Strip a few lines from beginning/end of file.
+    tail -n +7 |
+    head -n -7 |
 
-# Simple converter for gemtext to roff
-# Note that this is not a converter of "standard" gemtext, and is
-# designed specifically for kristall's about page. Thus, this may not work
-# as expected on other gemtext files (may require a little tweaking)
-convert_gemtext() {
-    gem_in="$(cat $1 | tail -n +7 | head -n -7)"
+    # First expression replaces all [Text like this] with bold text.
+    # Second expression replaces text like *This* or _this_ with italic text.
+    sed -E \
+      -e 's#\[([^]]*)\]#\\fB\1\\fR#g' \
+      -e 's#(^|[.,!? ]+)[*_]([^*_ ]+[^*_]+[^*_ ]+)[*_]($|[.,!? ])#\1\\fI\2\\fR\3#g'
+)
 
-    # Replace [Text] with bold text.
-    gem_in="$(echo "$gem_in" | sed -Ee 's#\[([^]]*)\]#\\fB\1\\fR#g')"
+# Convert gemtext to man format
+echo "$gem_in" | "$gemtext_converter" >> "$man_output"
 
-    # Replace *Text* or _text_ with italic (not bold to help differentiate with the above)
-    # (Regex is derived from one in geminirenderer.cpp)
-    gem_in="$(echo "$gem_in" | sed -Ee 's#(^|[.,!? ]+)[*_]([^*_ ]+[^*_]+[^*_ ]+)[*_]($|[.,!? ])#\1\\fI\2\\fR\3#g')"
-
-    is_preformatted=false
-
-    # Iterate over all the lines in the gemtext file
-    while IFS= read -r line; do
-        if echo "$line" | grep -q '^##\s'; then
-            # Top level heading
-            text="${line#'## '}"
-            echo ".SH"
-            echo "${text^^}"
-        elif echo "$line" | grep -q '^###\s'; then
-            # Level 2 heading
-            text="${line#'### '}"
-            echo ".SS"
-            echo "$text"
-        elif echo "$line" | grep -q '^\*\s'; then
-            # Lists
-            text="${line#'* '}"
-            echo ".IP \(bu 3"
-            echo "${text}"
-        elif echo "$line" | grep -q '^\=>'; then
-            # Links. We only show the URL itself if there is one.
-            text="${line#'=>'}"
-            title="$(echo "$text" | awk '{$1=""; print $0}')"
-            text="$(echo "$text" | awk '{print $1}')"
-
-            # Prefix with URL title if we have one
-            if [[ -n "$title" ]]; then
-                text="$title: $text"
-            fi
-
-            echo ".IP"
-
-            # Echo the text, we also strip leading whitespace
-            echo "$text" | sed -e 's#^[[:space:]]*##'
-        elif echo "$line" | grep -q '^```'; then
-            # Preformatted text. We just indent it
-            if [[ "$is_preformatted" = false ]]; then
-                echo ".RS"
-                is_preformatted=true
-            else
-                echo ".RE"
-                is_preformatted=false
-            fi
-        elif [[ -z "$line" ]]; then
-            # Empty lines
-            echo "."
-        else
-            # Regular paragraphs
-            echo ".PP"
-            echo "$line"
-        fi
-    done <<< "$gem_in"
-}
-
-main "$@"
+# Write the tail to the output file.
+cat "$man_tail" >> "$man_output"

--- a/doc/kristall-head.man
+++ b/doc/kristall-head.man
@@ -1,0 +1,31 @@
+.\"
+.\" Kristall man page
+.\"
+.
+.TH KRISTALL 1 $(DATE) Unix "User manuals"
+.SH NAME
+.PP
+.B kristall
+\- a cross-platform graphical small-internet client.
+.PP
+Kristall tries to fill the hole of graphical browsers for alternative internet protocols with a high usability and feature richness.
+.
+.SH SYNOPSIS
+.B kristall
+[\fI\,FLAGS\/\fR]... [\fI\,URL\/\fR]
+.
+.SH DESCRIPTION
+.P
+.B kristall
+is a small-Internet browser designed primarily for browsing geminispace. The gopher and finger protocols are also supported, as well as basic HTTP/S.
+.
+.SH FLAGS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Displays help information
+.
+.TP
+\fB\-v\fR, \fB\-\-version\fR
+Displays version information
+.
+.\" Stuff after this is converted from the Gemtext about:help file

--- a/doc/kristall-head.man
+++ b/doc/kristall-head.man
@@ -7,8 +7,6 @@
 .PP
 .B kristall
 \- a cross-platform graphical small-internet client.
-.PP
-Kristall tries to fill the hole of graphical browsers for alternative internet protocols with a high usability and feature richness.
 .
 .SH SYNOPSIS
 .B kristall
@@ -18,6 +16,7 @@ Kristall tries to fill the hole of graphical browsers for alternative internet p
 .P
 .B kristall
 is a small-Internet browser designed primarily for browsing geminispace. The gopher and finger protocols are also supported, as well as basic HTTP/S.
+It tries to fill the hole of graphical browsers for alternative internet protocols with a high usability and feature richness.
 .
 .SH FLAGS
 .TP

--- a/doc/kristall-head.man
+++ b/doc/kristall-head.man
@@ -15,8 +15,8 @@
 .SH DESCRIPTION
 .P
 .B kristall
-is a small-Internet browser designed primarily for browsing geminispace. The gopher and finger protocols are also supported, as well as basic HTTP/S.
-It tries to fill the hole of graphical browsers for alternative internet protocols with a high usability and feature richness.
+is a small-Internet browser primarily designed for browsing geminispace, but also supports gopher, finger, and basic HTTP/S.
+It tries to fill the hole of graphical browsers for these alternative Internet protocols, with a high usability, feature richness, and somewhat familiar interface for newcomers.
 .
 .SH FLAGS
 .TP

--- a/doc/kristall-tail.man
+++ b/doc/kristall-tail.man
@@ -1,0 +1,6 @@
+.\" End of converted Gemtext
+.
+.SH BUGS
+Bug tracker:
+.IP
+https://github.com/MasterQ32/kristall/issues

--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -1,5 +1,5 @@
 # Kristall Help
-This is the manual for the Kristall small-internet browser. It contains explanations on how to use the program, what each setting means and other information about the browser.
+This is the user manual for the Kristall small-internet browser. It contains explanations on how to use the program, what each setting means and other information about the browser.
 
 ## The Mission
 Kristall tries to fill the hole of graphical browsers for alternative internet protocols with a high usability and feature richness.
@@ -67,7 +67,7 @@ This menu contains means to navigate the internet.
 ### View
 This menu allows you to show/hide dockable dialogs.
 
-[Document Outline] toggles the document outline. Documents with text/gemini get an automatic outline generation that can be used to navigate larger documents quicker. This document is a good place to try that out!
+[Document Outline] toggles the document outline. Documents with text/gemini get an automatic outline generation that can be used to navigate larger documents quicker. If you're reading this help document in the browser, this is a good place to try this feature out!
 
 [Bookmarks] opens a dock containing a list of all your favourite sites. Open your bookmarks into a new tab by double-clicking the entries.
 
@@ -76,7 +76,7 @@ This menu allows you to show/hide dockable dialogs.
 ### Help
 This menu contains some stuff that provides help or information about Kristall.
 
-[Help] displays this document.
+[Help] displays the help manual (this document).
 
 [Changelog] will open a document that lists the changes in Kristall in a bulleted list.
 
@@ -300,7 +300,7 @@ This list contains all built-in shortcuts:
 * Alt+Up ⇒ Navigate to parent directory
 * Alt+Home ⇒ Go to home page
 * Alt+/ ⇒ Navigate to root directory
-* F1 ⇒ View this document
+* F1 ⇒ Open help manual
 * F5 ⇒ Refresh current tab
 
 ## Protocol support

--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -1,10 +1,13 @@
 # Kristall Help
+
 This is the user manual for the Kristall small-internet browser. It contains explanations on how to use the program, what each setting means and other information about the browser.
 
 ## The Mission
+
 Kristall tries to fill the hole of graphical browsers for alternative internet protocols with a high usability and feature richness.
 
 ## The main interface
+
 The main interface of Kristall consists of three parts:
 
 * the navigation bar on top,
@@ -12,6 +15,7 @@ The main interface of Kristall consists of three parts:
 * and the status bar on the bottom
 
 ### Navigation bar
+
 In the navigation bar, you have some buttons and your URL bar.
 
 You can enter any supported URL in the URL bar, press *Return* and Kristall will then load the page in the content view. You usually need to specify the url scheme to navigate to a specific site, but you can omit the gemini:// prefix for gemini pages. If you enter a URL with no scheme, and it looks like a URL (e.g "tilde.pink"), Kristall will assume that it is in fact a gemini URL. If you enter something in the URL bar that *doesn't* look like a URL (e.g "i like dogs"), it will be assumed a search query, and will be forwarded to the search engine that is set in the Settings.
@@ -23,6 +27,7 @@ On the right side of the URL bar you will find two buttons:
 * The button with the shield icon toggles the use of client certificates. Pressing it when no client certificate is enabled, a dialog will pop up asking you to select or create a certificate. When a certificate is enabled, the button will have a filled shield with a small lock in it. Pressing the button now will disable the currently used certificate. Note that if you're using a transient certificate, Kristall will ask you a safety question before destroying the certificate.
 
 ### Content view
+
 The content view renders the requested document. For hypertext documents (i.e gemtext, markdown, etc), you get a nicely rendered version of those documents, other text files are displayed in monospace. Audio and video files are played in a small built-in media player that allows you to play/pause the media, scroll around in the time line and mute/unmute audio. Images are rendered in an interactive view where you can drag the image around and zoom in/out with the mouse wheel.
 
 Documents that can't be rendered will be displayed with file size and mime type, so you can save them to disk and open the files with another program.
@@ -30,13 +35,16 @@ Documents that can't be rendered will be displayed with file size and mime type,
 Right-clicking in the content view will produce a menu which allows you to copy text, navigate back/forward in history, and copy or open links which are being hovered over. If you right click a HTTP/S link you will also see an option "Open with external web browser" which allows you to open these pages in your default WWW browser.
 
 ### Status bar
+
 The status bar displays auxiliary information:
 On the left, you can see the link target when you hover a link. On the right, you can see the document size, time needed to load the document and the mime type of the content. This is especially important when Kristall is not able to render the document nicely. A "(cached)" indicator will appear to the left of the mime type, indicating that the page has been read from cache.
 
 ## Menus
+
 This chapter explains what each menu button does. I hope that most stuff isn't surprising 😉
 
 ### File
+
 [New Tab] will open a new tab to surf.
 
 [Save as] allows you to save the currently displayed file to your disk.
@@ -50,6 +58,7 @@ This chapter explains what each menu button does. I hope that most stuff isn't s
 [Quit] will close Kristall.
 
 ### Navigation
+
 This menu contains means to navigate the internet.
 
 [Go to home] will navigate your current tab to your home page.
@@ -67,6 +76,7 @@ This menu contains means to navigate the internet.
 [Add to favourites] will add or remove the current page to/from your list of favourites.
 
 ### View
+
 This menu allows you to show/hide dockable dialogs.
 
 [Document Outline] toggles the document outline. Documents with text/gemini get an automatic outline generation that can be used to navigate larger documents quicker. If you're reading this help document inside of Kristall, this is a good place to try this feature out!
@@ -76,6 +86,7 @@ This menu allows you to show/hide dockable dialogs.
 [History] shows the surfing history of the current tab. Double-clicking an entry navigates back and forth in your history without disturbing the list.
 
 ### Help
+
 This menu contains some stuff that provides help or information about Kristall.
 
 [Help] displays the help manual (this document).
@@ -87,9 +98,11 @@ This menu contains some stuff that provides help or information about Kristall.
 [About Qt] shows a dialog containing legal information about the Qt version used.
 
 ## Settings
+
 Kristall offers a vast amount of settings. You can style the documents to your liking, changing fonts and colors. You can also fine-tune the behaviour of Kristall to match your likings and keep track of your trusted pages. Please note that Kristall has been designed mostly for browsing geminispace, thus many of these settings are specific or exclusive to Gemini only.
 
 ### Generic
+
 This tab contains an unsorted list of settings that allow you to tweak Kristalls behaviour.
 
 [UI Theme] controls whether the Qt interface is displayed in a dark or a light theme. Selecting [Light] or [Dark] will use the provided Qt light/dark themes. [OS Default] will use your system theme.
@@ -156,6 +169,7 @@ This is a purely cosmetic feature that may aid in readability.
 [Cached item life] is the amount of time in minutes before a single cached item is considered "expired." When a cached item is "expired", it is not read from cache, but instead re-retreived from the server. Cache life can be disabled by enabling the [Unlimited item life] option. Note: [Cached item life] is only recommended if you desperately want to keep your memory usage to a minimum, otherwise, having [Unlimited item life] is usually a great convenience, and due to the usually very small size of pages in geminispace, gopherspace, etc - it doesn't require much memory.
 
 ### Style
+
 In this tab, you can customise the document rendering in Kristall. The left pane contains a vast array of options to tweak, and the right pane displays a preview of your currently-selected style.
 Many items in the *Style* category have either a [Font], [Color], or both buttons. Click these to change the respective value.
 
@@ -218,6 +232,7 @@ Many items in the *Style* category have either a [Font], [Color], or both button
 The lone text with with the [host.name] text in it can be used to preview some auto-generated themes. It only refreshes the preview and seeds the auto generator with a new host name.
 
 ### Gemini TLS and HTTPS TLS
+
 These two sites contain the TLS settings for either Gemini or HTTPS. Both protocols are handled in the same way, but with different data sets, so each one has its own settings page.
 
 [Trust Level] defines how you trust hosts. [Trust on first encounter] is also known as *Trust On First Use* (or TOFU) and will store the servers public key in Kristalls database of trusted hosts. If a host is later encountered that has changed its public key, an error will be displayed to the user that this host may be compromised (as the changing of a public key can be a man-in-the-middle attack). [Trust everything] will just happily accept every TLS server, ignoring the certificate issuer completely. [Manually verify fingerprints] allows you to chose whether you trust a server or not based on its fingerprint. This will be displayed in the error page as well as the option to add that server to your list of trusted hosts.
@@ -229,6 +244,7 @@ These two sites contain the TLS settings for either Gemini or HTTPS. Both protoc
 [Revoke trust] allows you to remove a server from your database. Select a server in the list and click the button. Kristall will now act as it hasn't ever seen that server before and will now handle the server as an unknown one.
 
 ## Certificate Manager
+
 This dialog allows you to manage your client certificates. There are options to import, export, delete and create new certificates as well as manage your existing ones.
 
 The window is separated in two halves:
@@ -260,6 +276,7 @@ Using passphrases for importing/exporting certificates is currently not supporte
 Please note that changes in this dialog are immediaty applied and there is no way back when doing an action. This may change in the future, but will stay like this for now.
 
 ## Certificate Selection Dialog
+
 This dialog allows you to enable client certificates. It is opened by clicking the shield button in the navigation bar or it will automatically pop up when a site requests the use of a client certificate.
 
 In the upper part, this dialog provides you with a list of all your persistent certificates. If you want to use one of those, select the certificate and click [Use]. Or simply double-click a certificate to chose it.
@@ -267,6 +284,7 @@ You can also ad-hoc create a new certificate with the click on [Create new ident
 On the lower part you can create temporary certificates that have a short lifespan and will be destroyed as soon as you disable the certificate or close your client.
 
 ## Certificate Creation Dialog
+
 This dialog provides means to create a new persistent identity.
 
 [Group] is the name of the group where this certificate should be stored. You can either chose an existing group from the drop down or just enter a non-existing name to create a new group ad-hoc.
@@ -277,6 +295,7 @@ This dialog provides means to create a new persistent identity.
 With a click on [OK], Kristall will create a new certificate and put it in your certificate store. It can then be selected from the certificate selection dialog or certificate manager.
 
 ## Certificate I/O Dialog
+
 This dialog enables you to import or export certificate-key-pairs into or from Kristall.
 
 [Key Type] contains the type of your key. If you import, you need to select the correct key type there, if you export, it will be disabled, but shows the correct type of key for your identity.
@@ -284,6 +303,7 @@ This dialog enables you to import or export certificate-key-pairs into or from K
 [Certificate File] needs to be a full path to either a .der or .pem file where Kristall will load/store the certificate from/to.
 
 ## Shortcuts
+
 The following list contains all of Kristall's built-in shortcuts:
 
 * Ctrl+T ⇒ New tab
@@ -306,6 +326,7 @@ The following list contains all of Kristall's built-in shortcuts:
 * F5 ⇒ Refresh current tab
 
 ## Protocol support
+
 These protocols are currently supported via their respective URL schemes:
 => https://gemini.circumlunar.space/ Gemini
 => https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol HTTP/HTTPS
@@ -313,9 +334,11 @@ These protocols are currently supported via their respective URL schemes:
 => https://en.wikipedia.org/wiki/Finger_protocol Finger
 
 ### Gemini
+
 Kristall tries to implement the current feature set of the gemini specification. All response types of a gemini server are relayed to the user and the user choses when to do certain actions or not. Redirections are followed automatically, and you will be prompted depending on your configured Settings.
 
 ### Gopher
+
 Kristall provides access to gopherspace and supports most modern/common file types:
 * Gophermaps / Directories
 * Text
@@ -327,6 +350,7 @@ Kristall provides access to gopherspace and supports most modern/common file typ
 There is currently no support for automatic redirection on URL: resources or special/oldschool file types like DOS/HexBin/UUencoded data.
 
 ### Local file browsing
+
 The file:// scheme can be used to browse local files and directories on your system. (This feature has not been well-tested on Windows systems)
 
 Browsing to a local directory, such as file:///home/user will create a "directory listing", with links allowing you to navigate the file structure.
@@ -334,6 +358,7 @@ Browsing to a local directory, such as file:///home/user will create a "director
 Browsing to an actual file, such as file:///home/user/file.txt will cause Kristall to attempt to display that file.
 
 ### Built-in sites
+
 There is also the scheme about: which can be used to access internal sites for configuration, usability or help (this is one of them!):
 => about:blank
 => about:favourites
@@ -343,6 +368,7 @@ There is also the scheme about: which can be used to access internal sites for c
 => about:cache
 
 ## Security Concept
+
 Kristall has some built-in security measures to make your browsing experience safe and sane.
 
 ### Philosophy
@@ -363,6 +389,7 @@ It will also make some artificial hurdles when you can *really* make something t
 * Trusting TLS connections based on manually built lists, TOFU method or using the certificate authority system
 
 ## Caching
+
 Kristall has an in-memory page caching system enabled by default. This allows for quick loading of pages that have already been visited. Currently, this cache is cleared when Kristall is exited.
 
 The caching system is fairly basic; when a page is loaded, it is pushed to the cache (if it is smaller than [Cached item size threshold]). If the cache exceeds the [Total cache size limit], the oldest item in the cache is removed. The [Cached item life] determines how long this cached pages will be valid for.
@@ -372,6 +399,7 @@ When a page is read from cache, it is indicated in the Status Bar, to the left o
 If you would like to disable page caching, set the [Total cache size limit] to 0. See *Settings* for more information
 
 ## Supported Media Types
+
 * text/plain
 * text/gemini
 * text/html
@@ -384,6 +412,7 @@ If you would like to disable page caching, set the [Total cache size limit] to 0
 All unrecognized text files will be rendered as text/plain documents with a monospaced font.
 
 ## Contact me
+
 I'm eager to hear from your experience! Did everything work? Is something especially cool or bad? Tell me what you think or what annoys you!
 
 Please note that everything here is still work-in-progress and may crash!

--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -14,22 +14,24 @@ The main interface of Kristall consists of three parts:
 ### Navigation bar
 In the navigation bar, you have some buttons and your URL bar.
 
-You can enter any supported URL in the URL bar, press *Return* and Kristall will then load the page in the content view. You usually need to specify the url scheme to navigate to a site, but you can omit the gemini:// prefix for gemini pages. If the URL has no scheme, it will be automatically added by Kristall.
+You can enter any supported URL in the URL bar, press *Return* and Kristall will then load the page in the content view. You usually need to specify the url scheme to navigate to a specific site, but you can omit the gemini:// prefix for gemini pages. If you enter a URL with no scheme, and it looks like a URL (e.g "tilde.pink"), Kristall will assume that it is in fact a gemini URL. If you enter something in the URL bar that *doesn't* look like a URL (e.g "i like dogs"), it will be assumed a search query, and will be forwarded to the search engine that is set in the Settings.
 
-The two buttons on the left give you the ability to navigate back and forth in your browsing history. The button with the round arrow is the refresh button and allows you to reload the currently displayed site. While a site is loading, it is replaced with the stop button (square icon) that allows you to cancel the current request.
+The two buttons on the left of the navigation bar that give you the ability to navigate back and forth in your browsing history. The button with the round arrow is the refresh button and allows you to reload the currently displayed site. While a site is loading, it is replaced with the stop button (square icon) that allows you to cancel the current request. Tip: Some additional buttons can also be enabled in the settings, to quickly navigate to the home page, and even the 'root' and 'parent' of the current URL! (See [Additional Toolbar Items] in Settings)
 
 On the right side of the URL bar you will find two buttons:
-The button with the small heart in it will add or remove this page to your favourites, this can be done as well by pressing CTRL-D. When the heart on the button is filled, the site is contained in your favourites. If not, the heart has only a outline display.
-The button with the shield icon toggles your use of client certificates. Pressing it when no client certificate is enabled, a dialog will pop up asking you to select or create a certificate. When a certificate is enabled, the button will have a filled shield with a small lock in it. Pressing the button now will disable the currently used certificate. Note that if you're using a transient certificate, Kristall will ask you a safety question before destroying the certificate.
+* The button with the small heart icon in it will add or remove this page to your favourites, this can be done as well by pressing *Ctrl-D*. When the heart on the button is filled, the site is contained in your favourites. If not, the heart has only a outline display. Clicking this button will open a small menu to allow you to quickly place the favourite in a folder of your choosing (by default 'Unsorted'). You can press *Return* in this menu to quickly affirm the options displayed in it.
+* The button with the shield icon toggles the use of client certificates. Pressing it when no client certificate is enabled, a dialog will pop up asking you to select or create a certificate. When a certificate is enabled, the button will have a filled shield with a small lock in it. Pressing the button now will disable the currently used certificate. Note that if you're using a transient certificate, Kristall will ask you a safety question before destroying the certificate.
 
 ### Content view
-The content view renders the requested document. For hypertext documents, you get a nicely rendered version of those documents, other text files are displayed in monospace. Audio and video files are played in a small built-in media player that allows you to play/pause the media, scroll around in the time line and mute/unmute audio. Images are rendered in an interactive view where you can drag the image around and zoom in/out with the mouse wheel.
+The content view renders the requested document. For hypertext documents (i.e gemtext, markdown, etc), you get a nicely rendered version of those documents, other text files are displayed in monospace. Audio and video files are played in a small built-in media player that allows you to play/pause the media, scroll around in the time line and mute/unmute audio. Images are rendered in an interactive view where you can drag the image around and zoom in/out with the mouse wheel.
 
 Documents that can't be rendered will be displayed with file size and mime type, so you can save them to disk and open the files with another program.
 
+Right-clicking in the content view will produce a menu which allows you to copy text, navigate back/forward in history, and copy or open links which are being hovered over. If you right click a HTTP/S link you will also see an option "Open with external web browser" which allows you to open these pages in your default WWW browser.
+
 ### Status bar
 The status bar displays auxiliary information:
-On the left, you can see the link target when you hover a link. On the right, you can see the document size, time needed to load the document and the mime type of the content. This is especially important when Kristall is not able to render the document nicely.
+On the left, you can see the link target when you hover a link. On the right, you can see the document size, time needed to load the document and the mime type of the content. This is especially important when Kristall is not able to render the document nicely. A "(cached)" indicator will appear to the left of the mime type, indicating that the page has been read from cache.
 
 ## Menus
 This chapter explains what each menu button does. I hope that most stuff isn't surprising 😉
@@ -62,14 +64,14 @@ This menu contains means to navigate the internet.
 
 [Refresh] will reload the current page. This may be necessary for CGI scripts or other interactive content.
 
-[Add to favourites] will add or remove the current page to your list of favourites.
+[Add to favourites] will add or remove the current page to/from your list of favourites.
 
 ### View
 This menu allows you to show/hide dockable dialogs.
 
-[Document Outline] toggles the document outline. Documents with text/gemini get an automatic outline generation that can be used to navigate larger documents quicker. If you're reading this help document in the browser, this is a good place to try this feature out!
+[Document Outline] toggles the document outline. Documents with text/gemini get an automatic outline generation that can be used to navigate larger documents quicker. If you're reading this help document inside of Kristall, this is a good place to try this feature out!
 
-[Bookmarks] opens a dock containing a list of all your favourite sites. Open your bookmarks into a new tab by double-clicking the entries.
+[Favourites] opens a dock containing a list of all your favourite (a.k.a bookmarked) sites. Open your favourites into a new tab by double-clicking the entries. If you right click on an entry you will be presented with a menu in which you can edit the name or location of the entry, or delete it. Right-clicking in the window (not on an entry, not on a group) will allow you to create a new "group" of entries. Right clicking on a group will allow you to rename the group, or recursively delete it (be careful!).
 
 [History] shows the surfing history of the current tab. Double-clicking an entry navigates back and forth in your history without disturbing the list.
 
@@ -85,16 +87,16 @@ This menu contains some stuff that provides help or information about Kristall.
 [About Qt] shows a dialog containing legal information about the Qt version used.
 
 ## Settings
-Kristall offers a vast amount of settings. You can style the documents to your liking, changing fonts and colors. You can also fine-tune the behaviour of Kristall to match your likings and keep track of your trusted pages.
+Kristall offers a vast amount of settings. You can style the documents to your liking, changing fonts and colors. You can also fine-tune the behaviour of Kristall to match your likings and keep track of your trusted pages. Please note that Kristall has been designed mostly for browsing geminispace, thus many of these settings are specific or exclusive to Gemini only.
 
 ### Generic
 This tab contains an unsorted list of settings that allow you to tweak Kristalls behaviour.
 
-[UI Theme] controls whether the Qt interface is displayed in a dark or a light theme. You can adjust that to your system style or to your site rendering. The "OS Default" will use your system theme.
+[UI Theme] controls whether the Qt interface is displayed in a dark or a light theme. Selecting [Light] or [Dark] will use the provided Qt light/dark themes. [OS Default] will use your system theme.
 
-[Icon Theme] controls the specific icon set that the Qt interface will use. Usually, the default "Auto" option should be good enough, however for those using the "OS Default" theme, this option may be useful.
+[Icon Theme] controls the specific icon set that the Qt interface will use. Usually, the default [Auto] option should be good enough, however for those using the [OS Default] UI theme, this option may be useful.
 
-[Start Page] is the URL to the page that will be loaded for new tabs. Default is "about:favourites".
+[Start Page] is the URL to the page that will be loaded for new tabs. Default is [about:favourites].
 
 [Search Engine] is the search engine to use when typing non-URLs in the URL bar. A handful of Gemini search engines are provided as a drop-down. If you would like to specify your own, specify it in a format similar to the following:
 
@@ -108,11 +110,11 @@ Note the "%1" at the end of the URL. This is where search queries will be insert
 gemini://example2.com/search/another/%1
 ```
 
-[Enabled Protocols] allows you to fine-tune which protocols are fetched by Kristall. By default, only Gemini is enabled, all other protocols are disabled. Disabled protocols are either not served with an error message or forwarded to your OS handler for that URL scheme.
+[Enabled Protocols] allows you to fine-tune which protocols are fetched by Kristall. By default, only Gemini is enabled, all other protocols are disabled. Disabled protocols are either not served, and produce an error message, or are forwarded to your OS handler for that URL scheme.
 
 [Text Rendering] allows one to control whether Kristall parses text input files or not. This is usually set to [Fancy] which renders text/html, text/gemini, text/markdown and text/gophermap to a nice, hyperlinked display. When set to [Always plain text], Kristall will display all text/* files as plaintext files instead. This may be inconvenient, but necessary for misparsed sites.
 
-[Enable text highlights] allows you to enable an experimental feature that allows *highlighting* and _underlining_ text in text/gemini documents. It will probably misrender, but you can try it out anyways.
+[Enable text highlights] allows you to enable *bolding* and _underlining_ in text/gemini documents. Bolding **like this** also works.
 
 [Gopher Map] allows you to chose a modern iconized style for gopher maps or, if you are an old schooler, just use a textual description of the item types in the map.
 
@@ -147,19 +149,19 @@ This is a purely cosmetic feature that may aid in readability.
 * [Root] button takes you to the root directory of the current site. (See Menus>Navigation section for explanation of what this does).
 * [Parent] button takes you to the parent directory of the current site. (See Menus>Navigation section for explanation of what this does).
 
-[Total cache size limit] sets the total amount of memory that can be used to cache pages. By default this is set to 500 KiB, but can be set to 0 to completely disable the caching system. The larger this number is, the more memory you are allowing Kristall to use.
+[Total cache size limit] sets the total amount of memory that can be used by Kristall to cache pages. By default this is set to 500 KiB, but can be set to 0 to completely disable the caching system. The larger this number is, the more memory you are allowing Kristall to use.
 
 [Cached item size threshold] is the maximum size of a single cached item. By default this is set to 400 KiB. This prevents Kristall from caching any pages that are large from clogging up the in-memory cache.
 
-[Cached item life] is the amount of time in minutes before a single cached item is considered "expired." When a cached item is "expired", it is not read from cache, but instead re-retreived from the server. Cache life can be disabled by enabling the [Unlimited item life] option.
+[Cached item life] is the amount of time in minutes before a single cached item is considered "expired." When a cached item is "expired", it is not read from cache, but instead re-retreived from the server. Cache life can be disabled by enabling the [Unlimited item life] option. Note: [Cached item life] is only recommended if you desperately want to keep your memory usage to a minimum, otherwise, having [Unlimited item life] is usually a great convenience, and due to the usually very small size of pages in geminispace, gopherspace, etc - it doesn't require much memory.
 
 ### Style
-On this tab, you can tweak the document rendering in Kristall. On the left half you can see all possible colors and fonts you can tweak, on the right half of the window is a preview rendering with your currently selected style.
-Most items in the *Style* category have either a [Font], [Color] or both buttons. Click these to change the respective value.
+In this tab, you can customise the document rendering in Kristall. The left pane contains a vast array of options to tweak, and the right pane displays a preview of your currently-selected style.
+Many items in the *Style* category have either a [Font], [Color], or both buttons. Click these to change the respective value.
 
 [Background Color] is the color that fills the empty space in a document.
 
-[Standard Font] allows you to change the font that is used for all non-preformatted and non-heading text. Chose the color and font family/size/style.
+[Standard Font] allows you to change the font that is used for all non-preformatted and non-heading text. Choose the color and font family/size/style.
 
 [Preformatted Font] is the font and text color that is used for all <pre> tags in HTML or preformatted blocks in text/gemini. This should be a monospace font, otherwise ASCII art will break horribly. Note to MacOS X users: "Andale Mono" is a good font choice here.
 
@@ -258,7 +260,7 @@ Using passphrases for importing/exporting certificates is currently not supporte
 Please note that changes in this dialog are immediaty applied and there is no way back when doing an action. This may change in the future, but will stay like this for now.
 
 ## Certificate Selection Dialog
-This dialog allows you to enable client certificates. It is opend by clicking the shield button in the navigation bar or it will automatically pop up when a site requests the use of a client certificate.
+This dialog allows you to enable client certificates. It is opened by clicking the shield button in the navigation bar or it will automatically pop up when a site requests the use of a client certificate.
 
 In the upper part, this dialog provides you with a list of all your persistent certificates. If you want to use one of those, select the certificate and click [Use]. Or simply double-click a certificate to chose it.
 You can also ad-hoc create a new certificate with the click on [Create new identity]. This will open up the certificate creation dialog which allows you to create new identities.
@@ -282,7 +284,7 @@ This dialog enables you to import or export certificate-key-pairs into or from K
 [Certificate File] needs to be a full path to either a .der or .pem file where Kristall will load/store the certificate from/to.
 
 ## Shortcuts
-This list contains all built-in shortcuts:
+The following list contains all of Kristall's built-in shortcuts:
 
 * Ctrl+T ⇒ New tab
 * Ctrl+W ⇒ Close tab
@@ -311,7 +313,7 @@ These protocols are currently supported via their respective URL schemes:
 => https://en.wikipedia.org/wiki/Finger_protocol Finger
 
 ### Gemini
-Kristall tries to implement the current feature set of the gemini specification. All response types of a gemini server are relayed to the user and the user choses when to do certain actions or not. Redirections are followed automatically.
+Kristall tries to implement the current feature set of the gemini specification. All response types of a gemini server are relayed to the user and the user choses when to do certain actions or not. Redirections are followed automatically, and you will be prompted depending on your configured Settings.
 
 ### Gopher
 Kristall provides access to gopherspace and supports most modern/common file types:
@@ -324,6 +326,13 @@ Kristall provides access to gopherspace and supports most modern/common file typ
 
 There is currently no support for automatic redirection on URL: resources or special/oldschool file types like DOS/HexBin/UUencoded data.
 
+### Local file browsing
+The file:// scheme can be used to browse local files and directories on your system. (This feature has not been well-tested on Windows systems)
+
+Browsing to a local directory, such as file:///home/user will create a "directory listing", with links allowing you to navigate the file structure.
+
+Browsing to an actual file, such as file:///home/user/file.txt will cause Kristall to attempt to display that file.
+
 ### Built-in sites
 There is also the scheme about: which can be used to access internal sites for configuration, usability or help (this is one of them!):
 => about:blank
@@ -331,6 +340,7 @@ There is also the scheme about: which can be used to access internal sites for c
 => about:help
 => about:updates
 => about:style-preview
+=> about:cache
 
 ## Security Concept
 Kristall has some built-in security measures to make your browsing experience safe and sane.
@@ -351,6 +361,15 @@ It will also make some artificial hurdles when you can *really* make something t
 * Redirects check for cross-scheme or cross-host redirections.
 * Fine-grained customizations
 * Trusting TLS connections based on manually built lists, TOFU method or using the certificate authority system
+
+## Caching
+Kristall has an in-memory page caching system enabled by default. This allows for quick loading of pages that have already been visited. Currently, this cache is cleared when Kristall is exited.
+
+The caching system is fairly basic; when a page is loaded, it is pushed to the cache (if it is smaller than [Cached item size threshold]). If the cache exceeds the [Total cache size limit], the oldest item in the cache is removed. The [Cached item life] determines how long this cached pages will be valid for.
+
+When a page is read from cache, it is indicated in the Status Bar, to the left of the mime type.
+
+If you would like to disable page caching, set the [Total cache size limit] to 0. See *Settings* for more information
 
 ## Supported Media Types
 * text/plain


### PR DESCRIPTION
This PR adds a man page generation script. On Linux man pages are considered the go-to help resource by many, so I feel it's a good idea to create one

Currently, the script looks at the gemtext about:help document, and converts it to the man `roff` format. A 'head' and 'tail' are also added with manpage-specific things (flags, etc) in them.

I've opened this as a draft as there is mostly likely stuff that will have to be changed before actually merging this.

Things to consider:
* Currently, the script strips out the first and last 7 lines of the about:help document which don't really belong in the man page. I think there is a better approach to handling this.
* Not yet added to a make target, so it doesn't get generated automatically yet
* We need to work out where to actually store the man page when running `make install`. Might be `/usr/share/man/man1`?

Suggestions are appreciated!