### PR TITLE
Emoji toggle option

### DIFF
--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -132,6 +132,8 @@ with fancy Unicode quotes, which include the following:
 ```
 This is a purely cosmetic feature that may aid in readability.
 
+[Render emojis] allows you to toggle whether to render emojis using installed emoji fonts. Disabling this can help prevent text rendering issues due to emojis. Note that emojis are only supported in Kristall builds with Qt 5.13 or later.
+
 [Max. Number of Redirections] is a setting that allows you to restrict sites to redirect you only a certain number of times before erroring out. Setting this to 0 will disable redirections completely, displaying an error with the target URL.
 
 [Redirection Handling] allows you to fine-tune the way Kristall allows redirections. Each of the options defines if Kristall should ask you to allow the redirect or do it silently. [Ask for cross-scheme redirection] will pop up a message box if a host tries to redirect you from one URL scheme to another, e.g. when a web server redirects you from HTTP to HTTPS. [Ask for cross-host redirection] will pop up the message box for all redirections through host boundaries, e.g. when example.com redirects you to www.example.com. [Ask for cross-scheme or cross-host redirection] will enable both of the previous behaviours, asking when any cross-boundary redirection happens. [Ask for all redirections] will pop up a message box every time a server tries to redirect you, keeping you in full control over all redirections. [Silently redirect everything] is the exact oppositve of that, accepting all redirections without warning or notice.

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -229,7 +229,7 @@ void BrowserTab::navOneForward()
 
 void BrowserTab::navigateToRoot()
 {
-    if(this->is_internal_location) return;
+    if(this->current_location.scheme() == "about") return;
 
     QUrl url = this->current_location;
     url.setPath("/");
@@ -238,7 +238,7 @@ void BrowserTab::navigateToRoot()
 
 void BrowserTab::navigateToParent()
 {
-    if(this->is_internal_location) return;
+    if(this->current_location.scheme() == "about") return;
 
     QUrl url = this->current_location;
 
@@ -1321,12 +1321,12 @@ void BrowserTab::updateUrlBarStyle()
     QUrl url { this->ui->url_bar->text().trimmed() };
 
     // Set all text to default colour if url bar
-    // is focused, is at an internal location (like about:...),
+    // is focused, is at an about: location,
     // or has an invalid URL.
     if (!kristall::options.fancy_urlbar ||
         this->ui->url_bar->hasFocus() ||
         !url.isValid() ||
-        this->is_internal_location)
+        this->current_location.scheme() == "about")
     {
         // Disable styling
         if (!this->no_url_style)

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -301,6 +301,24 @@ void SettingsDialog::setOptions(const GenericSettings &options)
         this->ui->urlbarhl_none->setChecked(true);
     }
 
+    if (kristall::EMOJIS_SUPPORTED && this->current_options.emojis_enabled)
+    {
+        this->ui->emojis_on->setChecked(true);
+    }
+    else
+    {
+        this->ui->emojis_off->setChecked(true);
+
+        // Grey out emoji options on unsupported emoji builds
+        if (!kristall::EMOJIS_SUPPORTED)
+        {
+            this->ui->emojis_on->setEnabled(false);
+            this->ui->emojis_off->setEnabled(false);
+            this->ui->emojis_label->setToolTip(
+                this->ui->emojis_label->toolTip() + " (not supported in this build)");
+        }
+    }
+
     if(this->current_options.fancy_quotes) {
         this->ui->fancyquotes_on->setChecked(true);
     } else {
@@ -829,6 +847,16 @@ void SettingsDialog::on_urlbarhl_fancy_clicked()
 void SettingsDialog::on_urlbarhl_none_clicked()
 {
     this->current_options.fancy_urlbar = false;
+}
+
+void SettingsDialog::on_emojis_on_clicked()
+{
+    this->current_options.emojis_enabled = true;
+}
+
+void SettingsDialog::on_emojis_off_clicked()
+{
+    this->current_options.emojis_enabled = false;
 }
 
 void SettingsDialog::on_fancyquotes_on_clicked()

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -149,6 +149,9 @@ private slots:
     void on_fancyquotes_on_clicked();
     void on_fancyquotes_off_clicked();
 
+    void on_emojis_on_clicked();
+    void on_emojis_off_clicked();
+
     void on_redirection_mode_currentIndexChanged(int index);
 
     void on_max_redirects_valueChanged(int arg1);

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -373,37 +373,71 @@
         </layout>
        </item>
        <item row="13" column="0">
+        <widget class="QLabel" name="emojis_label">
+         <property name="text">
+          <string>Render emojis</string>
+         </property>
+         <property name="toolTip">
+          <string>Whether to render emojis in a page.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QRadioButton" name="emojis_on">
+           <property name="text">
+            <string>On</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">emojisBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="emojis_off">
+           <property name="text">
+            <string>Off</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">emojisBtnGroup</string>
+           </attribute>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="14" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="15" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -416,14 +450,14 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_99">
          <item>
           <widget class="QCheckBox" name="enable_home_btn">
@@ -455,7 +489,7 @@
          </item>
         </layout>
        </item>
-       <item row="17" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="label_30">
          <property name="text">
           <string>Total cache size limit</string>
@@ -465,7 +499,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <widget class="QSpinBox" name="cache_limit">
          <property name="suffix">
           <string> KiB</string>
@@ -479,7 +513,7 @@
         </widget>
        </item>
 
-       <item row="18" column="0">
+       <item row="19" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item size threshold</string>
@@ -489,7 +523,7 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="1">
+       <item row="19" column="1">
         <widget class="QSpinBox" name="cache_threshold">
          <property name="suffix">
           <string> KiB</string>
@@ -503,7 +537,7 @@
         </widget>
        </item>
 
-       <item row="19" column="0">
+       <item row="20" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item life</string>
@@ -513,7 +547,7 @@
          </property>
         </widget>
        </item>
-       <item row="19" column="1">
+       <item row="20" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_25">
          <item>
           <widget class="QSpinBox" name="cache_life">
@@ -1503,6 +1537,8 @@
   <tabstop>urlbarhl_none</tabstop>
   <tabstop>fancyquotes_on</tabstop>
   <tabstop>fancyquotes_off</tabstop>
+  <tabstop>emojis_on</tabstop>
+  <tabstop>emojis_off</tabstop>
   <tabstop>max_redirects</tabstop>
   <tabstop>redirection_mode</tabstop>
   <tabstop>network_timeout</tabstop>
@@ -1598,5 +1634,6 @@
   <buttongroup name="hiddenFilesBtnGroup"/>
   <buttongroup name="urlbarBtnGroup"/>
   <buttongroup name="quotesBtnGroup"/>
+  <buttongroup name="emojisBtnGroup"/>
  </buttongroups>
 </ui>

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -457,7 +457,10 @@ DocumentStyle DocumentStyle::derive(const QUrl &url) const
         if (kristall::EMOJIS_SUPPORTED &&
             kristall::options.emojis_enabled)
         {
+            // Redundant check to make compiler happy...
+        #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
             font.setFamilies(emojiFonts);
+        #endif
         }
         else
         {

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -69,6 +69,7 @@ struct GenericSettings
     bool show_hidden_files_in_dirs = false;
     bool fancy_urlbar = true;
     bool fancy_quotes = true;
+    bool emojis_enabled = true;
 
     // This is set automatically
     QColor fancy_urlbar_dim_colour;
@@ -155,6 +156,9 @@ namespace kristall
     void saveWindowState();
 
     extern QString default_font_family, default_font_family_fixed;
+
+    //! Whether emojis are supprted in current build configuration
+    extern const bool EMOJIS_SUPPORTED;
 }
 
 #endif // KRISTALL_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,15 @@ QDir kristall::dirs::offline_pages;
 QDir kristall::dirs::themes;
 QDir kristall::dirs::styles;
 
+// We need QFont::setFamilies for emojis to work properly,
+// Qt versions below 5.13 don't support this.
+const bool kristall::EMOJIS_SUPPORTED =
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+    false;
+#else
+    true;
+#endif
+
 QString toFingerprintString(QSslCertificate const & certificate)
 {
     return QCryptographicHash::hash(certificate.toDer(), QCryptographicHash::Sha256).toHex(':');
@@ -379,6 +388,10 @@ void GenericSettings::load(QSettings &settings)
 
     fancy_quotes = settings.value("fancy_quotes", true).toBool();
 
+    emojis_enabled = kristall::EMOJIS_SUPPORTED
+        ? settings.value("emojis_enabled", true).toBool()
+        : false;
+
     max_redirections = settings.value("max_redirections", 5).toInt();
     redirection_policy = RedirectionWarning(settings.value("redirection_policy ", WarnOnHostChange).toInt());
 
@@ -439,6 +452,13 @@ void GenericSettings::save(QSettings &settings) const
     settings.setValue("cache_threshold", cache_threshold);
     settings.setValue("cache_life", cache_life);
     settings.setValue("cache_unlimited_life", cache_unlimited_life);
+
+    if (kristall::EMOJIS_SUPPORTED)
+    {
+        // Save emoji pref only if emojis are supported, so if user changes to a build
+        // with emoji support, they get it out of the box.
+        settings.setValue("emojis_enabled", emojis_enabled);
+    }
 }
 
 

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -185,15 +185,15 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
                 outline.appendH1(heading, id);
 
-                cursor.setBlockFormat(text_style.heading_format);
-                cursor.insertText(replace_quotes(heading), fmt);
-                cursor.insertText("\n", text_style.standard);
-
                 // Use first heading as the page's title.
                 if (page_title != nullptr && page_title->isEmpty())
                 {
                     *page_title = heading;
                 }
+
+                cursor.setBlockFormat(text_style.heading_format);
+                cursor.insertText(replace_quotes(heading), fmt);
+                cursor.insertText("\n", text_style.standard);
             }
             else if (line.startsWith("=>"))
             {


### PR DESCRIPTION
This adds a preference to disable emojis, as requested in #166 

The preference is greyed out on builds with Qt version lower than 5.13 (i.e emojis unsupported)

Closes #166 

Also small changes: 
* page titles now use original quotation marks from the page (which are usually ASCII quotes) when typographer quotes are enabled. I think this is better as it ensures that the fancy quotes are only a *visual* enhancement to reading the page itself
* parent/root shortcuts now work in error pages and file:// pages