### PR TITLE
Add 'centre first H1' option

### DIFF
--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -192,10 +192,9 @@ Most items in the *Style* category have either a [Font], [Color] or both buttons
 [Other options] are a set of extra options to enhance your reading experience (and just look cool in general).
 
 * [Justify text] will make text fill the lines they are on. Note that this only works on gemtext pages.
+* [Centre first H1] will centre-align the first top-level heading in gemtext pages. This can look really cool with [Text width limit] enabled!
 
-* [Enable text width limit] will limit the length of text on pages. This works best in gemtext pages, but should also work fine for HTML pages. See below for setting the limit. This can significantly enhance readability of pages.
-
-[Text width limit] sets the maximum line length of text. By default this is set to 900px. If the window itself is smaller in width than the text width limit, the text width limit is "adjusted" to fit inside the window. As mentioned above, horizontal margins will also be applied here.
+[Text width limit] sets the maximum line length of text. By default this is set to 900px. If the window itself is smaller in width than the text width limit, the text width limit is "adjusted" to fit inside the window. As mentioned above, horizontal margins will also be applied here. The [Enabled] checkbox to the right of this option toggles whether this option is enabled or not. (Enabled by default)
 
 [Line height (paragraph)] is an additional spacing between paragraph text lines. By default this is set to 5px, and can help with readability. (Gemtext-only feature)
 

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -134,6 +134,8 @@ void SettingsDialog::setGeminiStyle(DocumentStyle const &style)
 
     this->ui->enable_justify_text->setChecked(this->current_style.justify_text);
 
+    this->ui->enable_centre_h1->setChecked(this->current_style.centre_h1);
+
     this->ui->enable_text_width->setChecked(this->current_style.text_width_enabled);
     this->ui->text_width->setEnabled(this->current_style.text_width_enabled);
     this->ui->text_width->setValue(this->current_style.text_width);
@@ -532,6 +534,12 @@ void SettingsDialog::on_page_margin_v_valueChanged(double value)
 void SettingsDialog::on_enable_justify_text_clicked(bool checked)
 {
     this->current_style.justify_text = checked;
+    this->reloadStylePreview();
+}
+
+void SettingsDialog::on_enable_centre_h1_clicked(bool checked)
+{
+    this->current_style.centre_h1 = checked;
     this->reloadStylePreview();
 }
 

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -87,6 +87,8 @@ private slots:
 
     void on_enable_text_width_clicked(bool arg1);
 
+    void on_enable_centre_h1_clicked(bool arg1);
+
     void on_text_width_valueChanged(int value);
 
     void on_line_height_p_valueChanged(double arg1);

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -1108,12 +1108,12 @@
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="enable_text_width">
+                <widget class="QCheckBox" name="enable_centre_h1">
                  <property name="text">
-                  <string>Enable text width limit</string>
+                  <string>Centre first H1 </string>
                  </property>
                  <property name="toolTip">
-                  <string>Whether to limit the width of formatted text on the page or not.</string>
+                  <string>Whether to centre the first top-level heading in the document.</string>
                  </property>
                 </widget>
                </item>
@@ -1131,20 +1131,34 @@
               </widget>
              </item>
              <item row="17" column="1">
-              <widget class="QSpinBox" name="text_width">
-               <property name="minimum">
-                <number>300</number>
-               </property>
-               <property name="value">
-                <number>900</number>
-               </property>
-               <property name="maximum">
-                <number>2000</number>
-               </property>
-               <property name="suffix">
-                <string> px</string>
-               </property>
-              </widget>
+              <layout class="QHBoxLayout" name="horizontalLayout_26">
+               <item>
+                <widget class="QSpinBox" name="text_width">
+                 <property name="minimum">
+                  <number>300</number>
+                 </property>
+                 <property name="value">
+                  <number>900</number>
+                 </property>
+                 <property name="maximum">
+                  <number>2000</number>
+                 </property>
+                 <property name="suffix">
+                  <string> px</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="enable_text_width">
+                 <property name="text">
+                  <string>Enabled</string>
+                 </property>
+                 <property name="toolTip">
+                  <string>Whether to limit the width of formatted text on the page or not.</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
 
              <item row="18" column="0">
@@ -1574,8 +1588,9 @@
   <tabstop>page_margin_h</tabstop>
   <tabstop>page_margin_v</tabstop>
   <tabstop>enable_justify_text</tabstop>
-  <tabstop>enable_text_width</tabstop>
+  <tabstop>enable_centre_h1</tabstop>
   <tabstop>text_width</tabstop>
+  <tabstop>enable_text_width</tabstop>
   <tabstop>line_height_p</tabstop>
   <tabstop>line_height_h</tabstop>
   <tabstop>indent_p</tabstop>

--- a/src/documentstyle.cpp
+++ b/src/documentstyle.cpp
@@ -146,6 +146,7 @@ DocumentStyle::DocumentStyle(bool do_init) : theme(Fixed),
         "lightblue", "magenta", "cyan", "white"}),
     justify_text(true),
     text_width_enabled(true),
+    centre_h1(false),
     line_height_p(5.0),
     line_height_h(5.0),
     indent_bq(1), indent_p(1), indent_h(0), indent_l(2),
@@ -272,6 +273,7 @@ bool DocumentStyle::save(QSettings &settings) const
 
         settings.setValue("justify_text", justify_text);
         settings.setValue("text_width_enabled", text_width_enabled);
+        settings.setValue("centre_h1", centre_h1);
         settings.setValue("text_width", text_width);
         settings.setValue("line_height_p", line_height_p);
         settings.setValue("line_height_h", line_height_h);
@@ -390,6 +392,7 @@ bool DocumentStyle::load(QSettings &settings)
 
             justify_text = settings.value("justify_text", justify_text).toBool();
             text_width_enabled = settings.value("text_width_enabled", text_width_enabled).toBool();
+            centre_h1 = settings.value("centre_h1", centre_h1).toBool();
             text_width = settings.value("text_width", text_width).toInt();
             line_height_p = settings.value("line_height_p", line_height_p).toDouble();
             line_height_h = settings.value("line_height_h", line_height_h).toDouble();

--- a/src/documentstyle.hpp
+++ b/src/documentstyle.hpp
@@ -53,7 +53,7 @@ struct DocumentStyle
 
     QStringList ansi_colors;
 
-    bool justify_text, text_width_enabled;
+    bool justify_text, text_width_enabled, centre_h1;
     double line_height_p;
     double line_height_h;
     int indent_bq, indent_p, indent_h, indent_l;

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
     QTextList *current_list = nullptr;
     bool blockquote = false;
 
-    bool centre_first_h1 = true;
+    bool centre_first_h1 = themed_style.centre_h1;
 
     outline.beginBuild();
 

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -51,6 +51,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
     QTextList *current_list = nullptr;
     bool blockquote = false;
 
+    bool centre_first_h1 = true;
+
     outline.beginBuild();
 
     int anchor_id = 0;
@@ -193,7 +195,20 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
                     *page_title = heading;
                 }
 
-                cursor.setBlockFormat(text_style.heading_format);
+                // Centre the first heading. We can't use the above code block
+                // for this because it doesn't get run on every re-render of the page
+                if (centre_first_h1)
+                {
+                    auto f = text_style.heading_format;
+                    f.setAlignment(Qt::AlignCenter);
+                    cursor.setBlockFormat(f);
+                    centre_first_h1 = false;
+                }
+                else
+                {
+                    cursor.setBlockFormat(text_style.heading_format);
+                }
+
                 cursor.insertText(replace_quotes(heading), fmt);
                 cursor.insertText("\n", text_style.standard);
             }


### PR DESCRIPTION
I thought this is a pretty cool little style feature. The first '#' in the page is centre-aligned. 

It's disabled by default.

![image](https://user-images.githubusercontent.com/42143005/109403428-bb17bf00-79b1-11eb-8f0b-3f18c9959566.png)
