### PR TITLE
Domain-relative URL fix

### DIFF
--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -242,7 +242,18 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
                 auto local_url = QUrl(link);
 
-                auto absolute_url = root_url.resolved(QUrl(link));
+                // Makes local URLs like the following work properly:
+                // Root:  gemini://cosmic.voyage
+                // Local: gemini:///sub_directory
+                if (local_url.scheme() == root_url.scheme() &&
+                    local_url.host().isEmpty() &&
+                    local_url.scheme() != "about" &&
+                    local_url.scheme() != "file")
+                {
+                    // qDebug() << "Adjusting local url: " << local_url;
+                    local_url = local_url.adjusted(QUrl::RemoveScheme | QUrl::RemoveAuthority);
+                }
+                auto absolute_url = root_url.resolved(local_url);
 
                 // qDebug() << link << title;
 

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -242,11 +242,11 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
                 auto local_url = QUrl(link);
 
-                // Makes local URLs like the following work properly:
-                // Root:  gemini://cosmic.voyage
-                // Local: gemini:///sub_directory
+                // Makes relative URLs with scheme provided (e.g gemini:///relative) work
+                // From RFC 1630: "If the scheme parts are different, the whole absolute URI must be given"
+                // therefor the schemes must be same for this to be allowed.
                 if (local_url.scheme() == root_url.scheme() &&
-                    local_url.host().isEmpty() &&
+                    local_url.authority().isEmpty() &&
                     local_url.scheme() != "about" &&
                     local_url.scheme() != "file")
                 {


### PR DESCRIPTION
A bit hacky but it seems to work fine without breaking anything else (at least nothing that I've found yet). Maybe someone else has a cleaner idea

Basically if we see a URL on the page that has no hostname, but has same scheme as the root URL, we remove the scheme from it and assume that it is a local URL. (we also have to strip the authority so that leading slashes '//' are removed). The about/file scheme checks might be unnecessary - they're just there to be safe

Closes #181