### PR TITLE
Fix #186

### DIFF
--- a/src/widgets/kristalltextbrowser.cpp
+++ b/src/widgets/kristalltextbrowser.cpp
@@ -141,5 +141,15 @@ void KristallTextBrowser::betterCopy()
     static const QRegularExpression REGEX_QUOTES_D("(“|”)"), REGEX_QUOTES_S("(‘|’)");
     text.replace(REGEX_QUOTES_D, "\"").replace(REGEX_QUOTES_S, "'");
 
+    // From docs:
+    // "If the selection obtained from an editor spans a line break, the text will
+    // contain a Unicode U+2029 paragraph separator character instead of a newline \n character"
+    // Hence, we replace with \r\n on Win$hit, and \n on all other platforms
+#ifdef Q_OS_WIN32
+    text.replace(QChar(0x2029), "\r\n");
+#else
+    text.replace(QChar(0x2029), "\n");
+#endif
+
     kristall::clipboard->setText(text);
 }


### PR DESCRIPTION
Closes #186 and implements [the proposed solution](https://github.com/MasterQ32/kristall/issues/186#issuecomment-791890139). Note that the issue was actually present on Linux too, and was a problem for all text blocks

From [QTextCursor doc](https://doc.qt.io/qt-5/qtextcursor.html#selectedText):
> If the selection obtained from an editor spans a line break, the text will contain a Unicode U+2029 paragraph separator character instead of a newline \n character

This fix simply replaces the U+2029 character in copied text with a `\r\n` on Windows, and `\n` on other platforms