### PR TITLE
main.cpp: use QLibraryInfo to get the exact i18n path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <QFontDatabase>
 #include <QLocalSocket>
 #include <QLocalServer>
+#include <QLibraryInfo>
 #include <cassert>
 
 ProtocolSetup       kristall::protocols;
@@ -386,7 +387,7 @@ int main(int argc, char *argv[])
     });
 
     QTranslator trans, qttrans;
-    qttrans.load(QLocale(), QLatin1String("qt"), "_", "../share/qt5/translations");
+    qttrans.load(QLocale(), QLatin1String("qt"), "_", QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     trans.load(QLocale(), QLatin1String("kristall"), QLatin1String("_"), QLatin1String(":/i18n"));
     app.installTranslator(&qttrans);
     app.installTranslator(&trans);


### PR DESCRIPTION
Qt translation files were chosen only when you were in /usr/*, because of the relative path.  Changing it to use QLibraryInfo fixes that.