### PR TITLE
ANSI escape code stuff

### DIFF
--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -151,6 +151,11 @@ This is a purely cosmetic feature that may aid in readability.
 
 [Render emojis] allows you to toggle whether to render emojis using installed emoji fonts. Disabling this can help prevent text rendering issues due to emojis. Note that emojis are only supported in Kristall builds with Qt 5.13 or later.
 
+[ANSI Escape Sequences] determines the method of handling ANSI escape codes. This allows a document to alter some of the format (colour, etc) of text.
+* [Ignore] ignores ANSI sequences and leaves them in the text. This option will often create eyesores out of pages that have fancy ANSI art!
+* [Interpret (preformatted text only)] will allow Kristall to interpret ANSI escape sequences in *preformatted* text blocks.
+* [Strip] is a hybrid of the above. It strips ANSI sequences from the text, and displays the text normally, as if the escape sequences were not there.
+
 [Max. Number of Redirections] is a setting that allows you to restrict sites to redirect you only a certain number of times before erroring out. Setting this to 0 will disable redirections completely, displaying an error with the target URL.
 
 [Redirection Handling] allows you to fine-tune the way Kristall allows redirections. Each of the options defines if Kristall should ask you to allow the redirect or do it silently. [Ask for cross-scheme redirection] will pop up a message box if a host tries to redirect you from one URL scheme to another, e.g. when a web server redirects you from HTTP to HTTPS. [Ask for cross-host redirection] will pop up the message box for all redirections through host boundaries, e.g. when example.com redirects you to www.example.com. [Ask for cross-scheme or cross-host redirection] will enable both of the previous behaviours, asking when any cross-boundary redirection happens. [Ask for all redirections] will pop up a message box every time a server tries to redirect you, keeping you in full control over all redirections. [Silently redirect everything] is the exact oppositve of that, accepting all redirections without warning or notice.

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -46,7 +46,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
 
     this->ui->ansi_escapes->clear();
     this->ui->ansi_escapes->addItem(tr("Ignore"), QVariant::fromValue<int>(int(AnsiEscRenderMode::ignore)));
-    this->ui->ansi_escapes->addItem(tr("Render"), QVariant::fromValue<int>(int(AnsiEscRenderMode::render)));
+    this->ui->ansi_escapes->addItem(tr("Interpret (preformatted text only)"), QVariant::fromValue<int>(int(AnsiEscRenderMode::render)));
     this->ui->ansi_escapes->addItem(tr("Strip"), QVariant::fromValue<int>(int(AnsiEscRenderMode::strip)));
 
     this->ui->list_symbol->clear();

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -44,6 +44,11 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
     this->ui->ui_density->addItem(tr("Compact"), QVariant::fromValue<int>(int(UIDensity::compact)));
     this->ui->ui_density->addItem(tr("Classic"), QVariant::fromValue<int>(int(UIDensity::classic)));
 
+    this->ui->ansi_escapes->clear();
+    this->ui->ansi_escapes->addItem(tr("Ignore"), QVariant::fromValue<int>(int(AnsiEscRenderMode::ignore)));
+    this->ui->ansi_escapes->addItem(tr("Render"), QVariant::fromValue<int>(int(AnsiEscRenderMode::render)));
+    this->ui->ansi_escapes->addItem(tr("Strip"), QVariant::fromValue<int>(int(AnsiEscRenderMode::strip)));
+
     this->ui->list_symbol->clear();
     this->ui->list_symbol->addItem(tr("Filled circle"), QVariant::fromValue<int>(int(QTextListFormat::Style::ListDisc)));
     this->ui->list_symbol->addItem(tr("Circle"), QVariant::fromValue<int>(int(QTextListFormat::Style::ListCircle)));
@@ -255,6 +260,16 @@ void SettingsDialog::setOptions(const GenericSettings &options)
             break;
         }
     }
+
+    this->ui->ansi_escapes->setCurrentIndex(0);
+    for(int i = 0; i < this->ui->ansi_escapes->count(); ++i)
+    {
+        if(this->ui->ansi_escapes->itemData(i).toInt() == int(options.ansi_escapes)) {
+            this->ui->ansi_escapes->setCurrentIndex(i);
+            break;
+        }
+    }
+
 
     this->ui->start_page->setText(this->current_options.start_page);
 
@@ -865,6 +880,11 @@ void SettingsDialog::on_emojis_on_clicked()
 void SettingsDialog::on_emojis_off_clicked()
 {
     this->current_options.emojis_enabled = false;
+}
+
+void SettingsDialog::on_ansi_escapes_currentIndexChanged(int index)
+{
+    this->current_options.ansi_escapes = AnsiEscRenderMode(this->ui->ansi_escapes->itemData(index).toInt());
 }
 
 void SettingsDialog::on_fancyquotes_on_clicked()

--- a/src/dialogs/settingsdialog.hpp
+++ b/src/dialogs/settingsdialog.hpp
@@ -154,6 +154,8 @@ private slots:
     void on_emojis_on_clicked();
     void on_emojis_off_clicked();
 
+    void on_ansi_escapes_currentIndexChanged(int index);
+
     void on_redirection_mode_currentIndexChanged(int index);
 
     void on_max_redirects_valueChanged(int arg1);

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -406,38 +406,53 @@
          </item>
         </layout>
        </item>
+
        <item row="14" column="0">
+        <widget class="QLabel" name="ansi_label">
+         <property name="text">
+          <string>ANSI Escape Sequences</string>
+         </property>
+         <property name="toolTip">
+          <string>Determine how to render ANSI escape sequences</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1">
+        <widget class="QComboBox" name="ansi_escapes"/>
+       </item>
+
+       <item row="15" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
           <string>Max. Number of Redirections</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="15" column="1">
         <widget class="QSpinBox" name="max_redirects">
          <property name="value">
           <number>5</number>
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
           <string>Redirection Handling</string>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <widget class="QComboBox" name="redirection_mode"/>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_28">
          <property name="text">
           <string>Network Timeout</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QSpinBox" name="network_timeout">
          <property name="suffix">
           <string> ms</string>
@@ -450,14 +465,14 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="label_29">
          <property name="text">
           <string>Additional toolbar buttons</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_99">
          <item>
           <widget class="QCheckBox" name="enable_home_btn">
@@ -489,7 +504,7 @@
          </item>
         </layout>
        </item>
-       <item row="18" column="0">
+       <item row="19" column="0">
         <widget class="QLabel" name="label_30">
          <property name="text">
           <string>Total cache size limit</string>
@@ -499,7 +514,7 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="1">
+       <item row="19" column="1">
         <widget class="QSpinBox" name="cache_limit">
          <property name="suffix">
           <string> KiB</string>
@@ -513,7 +528,7 @@
         </widget>
        </item>
 
-       <item row="19" column="0">
+       <item row="20" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item size threshold</string>
@@ -523,7 +538,7 @@
          </property>
         </widget>
        </item>
-       <item row="19" column="1">
+       <item row="20" column="1">
         <widget class="QSpinBox" name="cache_threshold">
          <property name="suffix">
           <string> KiB</string>
@@ -537,7 +552,7 @@
         </widget>
        </item>
 
-       <item row="20" column="0">
+       <item row="21" column="0">
         <widget class="QLabel" name="label_31">
          <property name="text">
           <string>Cached item life</string>
@@ -547,7 +562,7 @@
          </property>
         </widget>
        </item>
-       <item row="20" column="1">
+       <item row="21" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_25">
          <item>
           <widget class="QSpinBox" name="cache_life">

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -43,6 +43,13 @@ enum class IconTheme : int
     light = 1
 };
 
+enum class AnsiEscRenderMode : int
+{
+    ignore = 0,
+    render = 1,
+    strip = 2
+};
+
 struct GenericSettings
 {
     enum TextDisplay {
@@ -70,6 +77,7 @@ struct GenericSettings
     bool fancy_urlbar = true;
     bool fancy_quotes = true;
     bool emojis_enabled = true;
+    AnsiEscRenderMode ansi_escapes = AnsiEscRenderMode::render;
 
     // This is set automatically
     QColor fancy_urlbar_dim_colour;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,6 +745,14 @@ void GenericSettings::load(QSettings &settings)
         ? settings.value("emojis_enabled", true).toBool()
         : false;
 
+    QString ansi = settings.value("ansi_escapes", "render").toString();
+    if(ansi == "ignore")
+        ansi_escapes = AnsiEscRenderMode::ignore;
+    else if(ansi == "render")
+        ansi_escapes = AnsiEscRenderMode::render;
+    else if(ansi == "strip")
+        ansi_escapes = AnsiEscRenderMode::strip;
+
     max_redirections = settings.value("max_redirections", 5).toInt();
     redirection_policy = RedirectionWarning(settings.value("redirection_policy ", WarnOnHostChange).toInt());
 
@@ -787,6 +795,14 @@ void GenericSettings::save(QSettings &settings) const
     case UIDensity::classic: density = "classic"; break;
     }
     settings.setValue("ui_density", density);
+
+    QString ansi = "render";
+    switch(ansi_escapes) {
+    case AnsiEscRenderMode::ignore: ansi = "ignore"; break;
+    case AnsiEscRenderMode::render: ansi = "render"; break;
+    case AnsiEscRenderMode::strip: ansi = "strip"; break;
+    }
+    settings.setValue("ansi_escapes", ansi);
 
     settings.setValue("gophermap_display", (gophermap_display == FormattedText) ? "rendered" : "text");
     settings.setValue("use_os_scheme_handler", use_os_scheme_handler);

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -52,6 +52,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
     bool centre_first_h1 = themed_style.centre_h1;
 
+    QTextCharFormat preformatted_fmt = text_style.preformatted;
+
     outline.beginBuild();
 
     int anchor_id = 0;
@@ -88,7 +90,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
 
                 if (RENDER_ESCAPES)
                 {
-                    renderhelpers::renderEscapeCodes(line, text_style.preformatted, cursor);
+                    renderhelpers::renderEscapeCodes(line, preformatted_fmt, text_style.preformatted, cursor);
                     cursor.insertText("\n", text_style.preformatted);
                 }
                 else
@@ -298,6 +300,7 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
         else if (line.startsWith("```"))
         {
             verbatim = true;
+            preformatted_fmt = text_style.preformatted;
         }
         else
         {

--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -84,19 +84,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
             else
             {
                 cursor.setBlockFormat(text_style.preformatted_format);
-
-                // TODO: make this a preference
-                const bool RENDER_ESCAPES = true;
-
-                if (RENDER_ESCAPES)
-                {
-                    renderhelpers::renderEscapeCodes(line, preformatted_fmt, text_style.preformatted, cursor);
-                    cursor.insertText("\n", text_style.preformatted);
-                }
-                else
-                {
-                    cursor.insertText(line + "\n", text_style.preformatted);
-                }
+                renderhelpers::renderEscapeCodes(line, preformatted_fmt, text_style.preformatted, cursor);
+                cursor.insertText("\n", text_style.preformatted);
             }
 
             continue;

--- a/src/renderers/gophermaprenderer.cpp
+++ b/src/renderers/gophermaprenderer.cpp
@@ -60,6 +60,8 @@ std::unique_ptr<QTextDocument> GophermapRenderer::render(const QByteArray &input
 
     QTextBlockFormat non_list_format = cursor.blockFormat();
 
+    QTextCharFormat text_fmt = standard;
+
     char last_type = '1';
 
     QList<QByteArray> lines = input.split('\n');
@@ -149,7 +151,7 @@ std::unique_ptr<QTextDocument> GophermapRenderer::render(const QByteArray &input
         if (type == 'i')
         {
             const QString escapeRenderInput = title + "\n";
-            renderhelpers::renderEscapeCodes(escapeRenderInput.toUtf8(), standard, cursor);
+            renderhelpers::renderEscapeCodes(escapeRenderInput.toUtf8(), text_fmt, standard, cursor);
         }
         else
         {

--- a/src/renderers/plaintextrenderer.cpp
+++ b/src/renderers/plaintextrenderer.cpp
@@ -17,7 +17,8 @@ std::unique_ptr<QTextDocument> PlainTextRenderer::render(const QByteArray &input
     renderhelpers::setPageMargins(result.get(), style.margin_h, style.margin_v);
 
     QTextCursor cursor { result.get() };
-    renderhelpers::renderEscapeCodes(input, standard, cursor);
+    QTextCharFormat text_fmt = standard;
+    renderhelpers::renderEscapeCodes(input, text_fmt, standard, cursor);
 
     return result;
 }

--- a/src/renderers/renderhelpers.cpp
+++ b/src/renderers/renderhelpers.cpp
@@ -338,9 +338,8 @@ static QString cleanLineEndings(QString &input)
 }
 
 void renderhelpers::renderEscapeCodes(const QByteArray &input,
-    const QTextCharFormat& format, QTextCursor& cursor)
+    QTextCharFormat& format, const QTextCharFormat& defaultFormat, QTextCursor& cursor)
 {
-    auto textFormat = format;
     const auto tokens = input.split(escapeString);
     QString inputString = QString::fromUtf8(input);
     cleanLineEndings(inputString);
@@ -354,12 +353,12 @@ void renderhelpers::renderEscapeCodes(const QByteArray &input,
             if (escSequence == "[")
             {
                 it++;
-                parseCSI(input, it, textFormat, format, cursor);
+                parseCSI(input, it, format, defaultFormat, cursor);
             }
         }
         else
         {
-            cursor.insertText(currentCharacter, textFormat);
+            cursor.insertText(currentCharacter, format);
         }
     }
 }

--- a/src/renderers/renderhelpers.hpp
+++ b/src/renderers/renderhelpers.hpp
@@ -7,7 +7,7 @@
 
 namespace renderhelpers
 {
-    void renderEscapeCodes(const QByteArray &input, const QTextCharFormat& format, QTextCursor& cursor);
+    void renderEscapeCodes(const QByteArray &input, QTextCharFormat& format, const QTextCharFormat& defaultFormat, QTextCursor& cursor);
 
     void setPageMargins(QTextDocument *doc, int mh, int mv);
 }


### PR DESCRIPTION
* ANSI Escape sequences now work across multiple lines
* Preferences added to handle this (like mentioned over IRC): "ignore", "interpret (preformatted only)" and "strip"

Still only implemented for preformatted text. I haven't come across any pages which use it outside of preformatted blocks, and I don't know if we should actually allow it outside of them (might mess with the user's theme a little too much?)

![image](https://user-images.githubusercontent.com/42143005/110233295-3ad7f780-7f77-11eb-8bc3-6b1a0b481f36.png)
