### PR TITLE
manpage: fix generated date

### DIFF
--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -45,7 +45,7 @@ fi
 cp "$man_head" "$man_output"
 
 # Insert last modified date (use last-modified date of help.gemini)
-last_modified=$(date -r "$gemtext_in" +"%Y-%M-%d")
+last_modified=$(date -r "$gemtext_in" +"%F")
 sed -i "$man_output" -e 's#\$(DATE)#'"$last_modified"'#g'
 
 # Some pre-processing before giving our gemtext to the awk script.


### PR DESCRIPTION
The 'month' in the man page date was set to the 'minute' that the help file was last modified. This resulted in impossible dates like 2021-39-08 :rofl: 
This patch fixes this by using the %F format string when calling `date` in the generation script 