### PR TITLE
Session management: additions

### DIFF
--- a/src/browsertab.hpp
+++ b/src/browsertab.hpp
@@ -250,6 +250,8 @@ public:
 
     bool was_read_from_cache = false;
 
+    bool lazy_loading = false;
+
     RequestState request_state;
 
     DocumentStyle current_style;

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -50,7 +50,7 @@ enum class AnsiEscRenderMode : int
     strip = 2
 };
 
-struct PageMetadata
+struct NamedUrl
 {
     QUrl location;
     QString title;
@@ -215,7 +215,7 @@ namespace kristall
     //! Opens a new window with the given list of urls.
     //! If the list is empty, no new tab will spawned.
     MainWindow * openNewWindow(QVector<QUrl> const & urls);
-    MainWindow * openNewWindow(QVector<PageMetadata> const & urls);
+    MainWindow * openNewWindow(QVector<NamedUrl> const & urls);
 
     //! Returns the number of currently open windows
     int getWindowCount();

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -50,6 +50,12 @@ enum class AnsiEscRenderMode : int
     strip = 2
 };
 
+struct PageMetadata
+{
+    QUrl location;
+    QString title;
+};
+
 struct GenericSettings
 {
     enum TextDisplay {
@@ -209,6 +215,7 @@ namespace kristall
     //! Opens a new window with the given list of urls.
     //! If the list is empty, no new tab will spawned.
     MainWindow * openNewWindow(QVector<QUrl> const & urls);
+    MainWindow * openNewWindow(QVector<PageMetadata> const & urls);
 
     //! Returns the number of currently open windows
     int getWindowCount();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -339,19 +339,33 @@ MainWindow * kristall::openNewWindow(QUrl const & url)
     return openNewWindow(QVector<QUrl>{url});
 }
 
-//! Opens a new window with the given list of urls.
-//! If the list is empty, no new tab will spawned.
+//! Opens a new window with the given urls.
+//! Almost identical to below overload.
 MainWindow * kristall::openNewWindow(QVector<QUrl> const & urls)
 {
     MainWindow * const window = new MainWindow(qApp);
 
     for(int i = 0; i < urls.length(); i++)
     {
-        window->addNewTab((i == 0), urls.at(i));
+        window->addNewTab((i == 0), urls.at(i), "");
     }
 
     window->show();
+    return window;
+}
 
+//! Opens a new window with the given list of urls.
+//! If the list is empty, no new tab will spawned.
+MainWindow * kristall::openNewWindow(QVector<PageMetadata> const & urls)
+{
+    MainWindow * const window = new MainWindow(qApp);
+
+    for(int i = 0; i < urls.length(); i++)
+    {
+        window->addNewTab((i == 0), urls.at(i).location, urls.at(i).title);
+    }
+
+    window->show();
     return window;
 }
 
@@ -692,13 +706,16 @@ int main(int argc, char *argv[])
         {
             settings.setArrayIndex(index);
 
-            QVector<QUrl> urls;
+            QVector<PageMetadata> urls;
 
             int tab_count = settings.beginReadArray("tabs");
             for(int i = 0; i < tab_count; i++)
             {
                 settings.setArrayIndex(i);
-                urls.push_back(settings.value("url").toString());
+                urls.push_back({
+                    settings.value("url").toString(),
+                    settings.value("title").toString()
+                });
             }
             settings.endArray();
 
@@ -1065,6 +1082,7 @@ void kristall::saveSession()
         {
             settings.setArrayIndex(i);
             settings.setValue("url", main_window->tabAt(i)->current_location.toString(QUrl::FullyEncoded));
+            settings.setValue("title", main_window->tabAt(i)->page_title);
             tab_count += 1;
         }
         settings.endArray();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -356,7 +356,7 @@ MainWindow * kristall::openNewWindow(QVector<QUrl> const & urls)
 
 //! Opens a new window with the given list of urls.
 //! If the list is empty, no new tab will spawned.
-MainWindow * kristall::openNewWindow(QVector<PageMetadata> const & urls)
+MainWindow * kristall::openNewWindow(QVector<NamedUrl> const & urls)
 {
     MainWindow * const window = new MainWindow(qApp);
 
@@ -706,7 +706,7 @@ int main(int argc, char *argv[])
         {
             settings.setArrayIndex(index);
 
-            QVector<PageMetadata> urls;
+            QVector<NamedUrl> urls;
 
             int tab_count = settings.beginReadArray("tabs");
             for(int i = 0; i < tab_count; i++)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -347,7 +347,7 @@ MainWindow * kristall::openNewWindow(QVector<QUrl> const & urls)
 
     for(int i = 0; i < urls.length(); i++)
     {
-        window->addNewTab((i == 0), urls.at(i), "");
+        window->addNewTab((i == 0), urls.at(i), true, "");
     }
 
     window->show();
@@ -362,7 +362,7 @@ MainWindow * kristall::openNewWindow(QVector<PageMetadata> const & urls)
 
     for(int i = 0; i < urls.length(); i++)
     {
-        window->addNewTab((i == 0), urls.at(i).location, urls.at(i).title);
+        window->addNewTab((i == 0), urls.at(i).location, true, urls.at(i).title);
     }
 
     window->show();
@@ -721,8 +721,12 @@ int main(int argc, char *argv[])
 
             auto * const window = kristall::openNewWindow(urls);
 
-            int tab_index = settings.value("tab_index").toInt();
-            window->setCurrentTabIndex(tab_index);
+            if (window->tabCount() > 0)
+            {
+                int tab_index = settings.value("tab_index").toInt();
+                window->setCurrentTabIndex(tab_index);
+                window->curTab()->reloadPage();
+            }
 
             if(settings.contains("state")) {
                 window->restoreState(settings.value("state").toByteArray());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -704,6 +704,9 @@ int main(int argc, char *argv[])
 
             auto * const window = kristall::openNewWindow(urls);
 
+            int tab_index = settings.value("tab_index").toInt();
+            window->setCurrentTabIndex(tab_index);
+
             if(settings.contains("state")) {
                 window->restoreState(settings.value("state").toByteArray());
             }
@@ -1065,6 +1068,8 @@ void kristall::saveSession()
             tab_count += 1;
         }
         settings.endArray();
+
+        settings.setValue("tab_index", main_window->currentTabIndex());
 
         window_index += 1;
     });

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -160,13 +160,23 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
     return tab;
 }
 
-BrowserTab * MainWindow::addNewTab(bool focus_new, QUrl const & url, QString defaultTitle)
+BrowserTab * MainWindow::addNewTab(bool focus_new, QUrl const & url, bool lazyload, QString defaultTitle)
 {
     auto tab = addEmptyTab(focus_new, false);
-    tab->navigateTo(url, BrowserTab::PushImmediate);
+
+    if (lazyload)
+    {
+        tab->current_location = url;
+        tab->lazy_loading = true;
+    }
+    else
+    {
+        tab->navigateTo(url, BrowserTab::PushImmediate);
+    }
 
     if (!defaultTitle.isEmpty())
     {
+        tab->page_title = defaultTitle;
         emit tab->titleChanged(defaultTitle);
     }
 
@@ -372,6 +382,11 @@ void MainWindow::on_browser_tabs_currentChanged(int index)
             else
             {
                 tab->refreshFavButton();
+            }
+
+            if (tab->lazy_loading)
+            {
+                tab->reloadPage();
             }
 
             this->setRequestState(tab->request_state);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -387,6 +387,7 @@ void MainWindow::on_browser_tabs_currentChanged(int index)
             if (tab->lazy_loading)
             {
                 tab->reloadPage();
+                tab->lazy_loading = false;
             }
 
             this->setRequestState(tab->request_state);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -160,10 +160,16 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
     return tab;
 }
 
-BrowserTab * MainWindow::addNewTab(bool focus_new, QUrl const & url)
+BrowserTab * MainWindow::addNewTab(bool focus_new, QUrl const & url, QString defaultTitle)
 {
     auto tab = addEmptyTab(focus_new, false);
     tab->navigateTo(url, BrowserTab::PushImmediate);
+
+    if (!defaultTitle.isEmpty())
+    {
+        emit tab->titleChanged(defaultTitle);
+    }
+
     return tab;
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -81,44 +81,43 @@ MainWindow::MainWindow(QApplication * app, QWidget *parent) :
     {
         std::string prefix = "Alt+";
         for (char tab = '0'; tab <= '9'; ++tab) {
-	  std::string shortcut = prefix + tab;
-          QShortcut * sc = new QShortcut(QKeySequence(shortcut.c_str()), this);
-          connect(sc, &QShortcut::activated, this,
-	  	[this, tab](){
-		  // 1-9 goes from the first to the n-th tab, 0 goes to the last one
-		  this->ui->browser_tabs->
-		    setCurrentIndex((tab == '0' ?
-				     this->ui->browser_tabs->count()
-				    : tab-'0') - 1);
-		});
-      }
+            std::string shortcut = prefix + tab;
+            QShortcut * sc = new QShortcut(QKeySequence(shortcut.c_str()), this);
+            connect(sc, &QShortcut::activated, this, [this, tab]()
+            {
+                // 1-9 goes from the first to the n-th tab, 0 goes to the last one
+                setCurrentTabIndex((tab == '0'
+                    ? this->ui->browser_tabs->count()
+                    : tab-'0') - 1);
+            });
+        }
     }
 
     {
         QShortcut * sc = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_PageDown), this);
         connect(sc, &QShortcut::activated, this, [this](){
-           int i = this->ui->browser_tabs->currentIndex();
+           int i = this->currentTabIndex();
 
            if (i + 1 >= this->ui->browser_tabs->count())
                i = 0;
            else
                i++;
 
-           this->ui->browser_tabs->setCurrentIndex(i);
+           this->setCurrentTabIndex(i);
         });
     }
 
     {
         QShortcut * sc = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_PageUp), this);
         connect(sc, &QShortcut::activated, this, [this](){
-           int i = this->ui->browser_tabs->currentIndex();
+           int i = this->currentTabIndex();
 
            if (!i)
                i = this->ui->browser_tabs->count() - 1;
            else
                i--;
 
-           this->ui->browser_tabs->setCurrentIndex(i);
+           this->setCurrentTabIndex(i);
         });
     }
 
@@ -148,7 +147,7 @@ BrowserTab * MainWindow::addEmptyTab(bool focus_new, bool load_default)
     int index = this->ui->browser_tabs->addTab(tab, "Page");
 
     if(focus_new) {
-        this->ui->browser_tabs->setCurrentIndex(index);
+        this->setCurrentTabIndex(index);
     }
 
     if(load_default) {
@@ -307,6 +306,17 @@ void MainWindow::applySettings()
     // Update new-tab button visibility.
     this->ui->browser_tabs->tab_bar->new_tab_btn->setVisible(kristall::globals().options.enable_newtab_btn);
 }
+
+int MainWindow::currentTabIndex()
+{
+    return this->ui->browser_tabs->currentIndex();
+}
+
+void MainWindow::setCurrentTabIndex(int index)
+{
+    this->ui->browser_tabs->setCurrentIndex(index);
+}
+
 
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
@@ -598,7 +608,7 @@ void MainWindow::on_tab_fileLoaded(DocumentStats const & stats)
     if(tab != nullptr) {
         int index = this->ui->browser_tabs->indexOf(tab);
         assert(index >= 0);
-        if(index == this->ui->browser_tabs->currentIndex()) {
+        if(index == this->currentTabIndex()) {
             setFileStatus(stats);
             this->ui->outline_view->expandAll();
         }
@@ -611,7 +621,7 @@ void MainWindow::on_tab_requestStateChanged(RequestState state)
     if(tab != nullptr) {
         int index = this->ui->browser_tabs->indexOf(tab);
         assert(index >= 0);
-        if(index == this->ui->browser_tabs->currentIndex()) {
+        if(index == this->currentTabIndex()) {
             setRequestState(state);
         }
     }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -49,6 +49,10 @@ public:
     //! Applies setting changes to the window.
     void applySettings();
 
+    //! Gets/sets the current tab of this window
+    int currentTabIndex();
+    void setCurrentTabIndex(int);
+
     void mousePressEvent(QMouseEvent *event) override;
 
     void closeEvent(QCloseEvent *event) override;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -31,7 +31,7 @@ public:
     ~MainWindow();
 
     BrowserTab * addEmptyTab(bool focus_new, bool load_default);
-    BrowserTab * addNewTab(bool focus_new, QUrl const & url);
+    BrowserTab * addNewTab(bool focus_new, QUrl const & url, QString defaultTitle="");
     BrowserTab * curTab() const;
     BrowserTab * tabAt(int index) const;
     int tabCount() const;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -31,7 +31,10 @@ public:
     ~MainWindow();
 
     BrowserTab * addEmptyTab(bool focus_new, bool load_default);
-    BrowserTab * addNewTab(bool focus_new, QUrl const & url, QString defaultTitle="");
+    BrowserTab * addNewTab(bool focus_new,
+        QUrl const & url,
+        bool lazyload=false,
+        QString defaultTitle="");
     BrowserTab * curTab() const;
     BrowserTab * tabAt(int index) const;
     int tabCount() const;


### PR DESCRIPTION
* The last tab being viewed is now restored.
* Tab *titles* are now also saved in the session.ini file alongside their URLs, so that titles are immediately displayed even before loading the pages.
* "Lazyloading" of tabs is added (similar to what web browsers do) - when we restore tabs/windows, only the active tab's page is downloaded. Other tabs are not loaded until the user navigates to that tab