### PR TITLE
Strip carriage-returns in gemtext

### DIFF
--- a/src/renderers/geminirenderer.cpp
+++ b/src/renderers/geminirenderer.cpp
@@ -65,6 +65,8 @@ std::unique_ptr<GeminiDocument> GeminiRenderer::render(
     QList<QByteArray> lines = input.split('\n');
     for (auto &line : lines)
     {
+        line.replace("\r", "");
+
         if (verbatim)
         {
             if (line.startsWith("```"))


### PR DESCRIPTION
When viewing gemtext documents that contain CR-LF line endings (such as gemini://idiomdrottning.org/nft), the lines get doubled up, which obviously looks a bit odd.

This patch just strips all CRs from lines in gemtext documents, as there doesn't seem to be any actual reason to have them in there; at least not any reasons I can think of.