### PR TITLE
MarkdownRenderer: remove resetFormatting function from blockquotes

### DIFF
--- a/src/renderers/markdownrenderer.cpp
+++ b/src/renderers/markdownrenderer.cpp
@@ -143,7 +143,6 @@ static void renderNode(RenderState &state, cmark_node & node, const QTextCharFor
         renderChildren(state, node, current_format);
 
         cursor.movePosition(QTextCursor::NextBlock);
-        resetFormatting(state);
         break;
     }
     case CMARK_NODE_LIST:


### PR DESCRIPTION
It caused some spacing issues with nested blockquotes.

Before:
![before](https://user-images.githubusercontent.com/16520278/114082284-d7125880-98ad-11eb-9ba5-ae061798b565.png)

After:
![after](https://user-images.githubusercontent.com/16520278/114082383-f4472700-98ad-11eb-834a-1f8c71c4a2ee.png)
