### PR TITLE
Respect *FLAGS environment variables.

### DIFF
--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -21,15 +21,11 @@ DEFINES += KRISTALL_VERSION="\"$(shell cd $$PWD; git describe --tags)\""
 # We need iconv on non-linux platforms
 !linux: LIBS += -liconv
 
-# On linux systems that have dpkg, append build flags for hardening
-linux {
-    system("which dpkg-buildflags") {
-        QMAKE_CPPFLAGS *= $(shell dpkg-buildflags --get CPPFLAGS)
-        QMAKE_CFLAGS   *= $(shell dpkg-buildflags --get CFLAGS)
-        QMAKE_CXXFLAGS *= $(shell dpkg-buildflags --get CXXFLAGS)
-        QMAKE_LFLAGS   *= $(shell dpkg-buildflags --get LDFLAGS)
-    }
-}
+# Initialize build flags from environment variables.
+QMAKE_CFLAGS   *= $$(CFLAGS)
+QMAKE_CXXFLAGS *= $$(CXXFLAGS)
+QMAKE_CPPFLAGS *= $$(CPPFLAGS)
+QMAKE_LFLAGS   *= $$(LDFLAGS)
 
 QMAKE_CFLAGS += -Wno-unused-parameter -Werror=return-type
 QMAKE_CXXFLAGS += -Wno-unused-parameter -Werror=return-type


### PR DESCRIPTION
This initializes QMAKE_CFLAGS, QMAKE_CXXFLAGS and QMAKE_LFLAGS with the
corresponding environment variables on all OSs. The variables will be
expanded when qmake is run[1].

This is a generalization of #171.

[1] <https://doc.qt.io/archives/qt-4.8/qmake-advanced-usage.html#variables>

@charles2910 You'll probably need to update your build script when this PR is merged.