### PR TITLE
Save settings on exit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1121,5 +1121,5 @@ void kristall::saveSession()
 
     qDebug() << "Saved session with" << window_index << "windows and" << tab_count << "tabs in total.";
 
-    settings.sync();
+    kristall::saveSettings();
 }


### PR DESCRIPTION
0d1fd257093c58bfb606aaac530aed3b0877f7fd changed `kristall::saveSettings()` to `settings.sync()` which caused bookmarks not to be saved.