### PR TITLE
BrowserTab: reset image scaling for small images

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -736,6 +736,8 @@ void BrowserTab::renderPage(const QByteArray &data, const MimeType &mime)
 
                 if (imageSize.width() > browserSize.width() || imageSize.height() > browserSize.height())
                     this->ui->graphics_browser->fitInView(graphics_scene.sceneRect(), Qt::KeepAspectRatio);
+                else
+                    this->ui->graphics_browser->resetTransform();
 
                 this->ui->graphics_browser->setSceneRect(graphics_scene.sceneRect());
             });


### PR DESCRIPTION
When you viewed a small image after the bigger one in the same tab, then the `graphics_browser` was still trying to scale them to the window size.