### PR TITLE
.gitattributes: exclude libraries from GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+lib/**/* linguist-vendored
+doc/*.sh -linguist-documentation
+doc/*.awk -linguist-documentation


### PR DESCRIPTION
As you can see in [my private fork](https://github.com/krkk/kristall), github now properly detects the language of this project!

https://github.com/github/linguist/blob/master/docs/overrides.md

[skip ci]