### PR TITLE
Unwarp tr() from QStrings

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -196,7 +196,7 @@ void BrowserTab::navigateTo(const QUrl &url, PushToHistory mode, RequestFlags fl
     this->timer.start();
 
     if(not this->startRequest(url, ProtocolHandler::Default, flags)) {
-        QMessageBox::critical(this, tr("Kristall"), QString(tr("Failed to execute request to %1")).arg(url.toString()));
+        QMessageBox::critical(this, tr("Kristall"), tr("Failed to execute request to %1").arg(url.toString()));
         return;
     }
 
@@ -289,13 +289,13 @@ void BrowserTab::openSourceView()
     monospace_font.setStyleHint(QFont::Monospace);
 
     auto dialog = std::make_unique<QDialog>(this, Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
-    dialog->setWindowTitle(QString(tr("Source of %0")).arg(this->current_location.toString()));
+    dialog->setWindowTitle(tr("Source of %0").arg(this->current_location.toString()));
 
     auto layout = new QVBoxLayout(dialog.get());
     dialog->setLayout(layout);
 
     auto hint = new QLabel(dialog.get());
-    hint->setText(QString(tr("Mime type: %0")).arg(current_mime.toString()));
+    hint->setText(tr("Mime type: %0").arg(current_mime.toString()));
     layout->addWidget(hint);
 
     auto text = new QPlainTextEdit(dialog.get());
@@ -451,7 +451,7 @@ void BrowserTab::on_certificateRequired(const QString &reason)
 
     if (not trySetClientCertificate(reason))
     {
-        setErrorMessage(QString(tr("The page requested a authorized client certificate, but none was provided.\r\nOriginal query was: %1")).arg(reason));
+        setErrorMessage(tr("The page requested a authorized client certificate, but none was provided.\r\nOriginal query was: %1").arg(reason));
     }
     else
     {
@@ -559,11 +559,11 @@ void BrowserTab::on_requestComplete(const QByteArray &ref_data, const MimeType &
             auto response = QMessageBox::question(
                 this,
                 tr("Kristall"),
-                QString(tr("Failed to convert input charset %1 to UTF-8. Cannot display the file.\r\nDo you want to display unconverted data anyways?")).arg(charset)
+                tr("Failed to convert input charset %1 to UTF-8. Cannot display the file.\r\nDo you want to display unconverted data anyways?").arg(charset)
             );
 
             if(response != QMessageBox::Yes) {
-                setErrorMessage(QString(tr("Failed to convert input charset %1 to UTF-8.")).arg(charset));
+                setErrorMessage(tr("Failed to convert input charset %1 to UTF-8.").arg(charset));
                 return;
             }
         }
@@ -856,7 +856,7 @@ void BrowserTab::on_inputRequired(const QString &query, const bool is_sensitive)
     {
         if (dialog.exec() != QDialog::Accepted)
         {
-            setErrorMessage(QString(tr("Site requires input:\n%1")).arg(query));
+            setErrorMessage(tr("Site requires input:\n%1").arg(query));
             return;
         }
 
@@ -893,7 +893,7 @@ void BrowserTab::on_redirected(QUrl uri, bool is_permanent)
 
     if (redirection_count >= kristall::globals().options.max_redirections)
     {
-        setErrorMessage(QString(tr("Too many consecutive redirections. The last redirection would have redirected you to:\r\n%1")).arg(uri.toString(QUrl::FullyEncoded)));
+        setErrorMessage(tr("Too many consecutive redirections. The last redirection would have redirected you to:\r\n%1").arg(uri.toString(QUrl::FullyEncoded)));
         return;
     }
     else
@@ -944,7 +944,7 @@ void BrowserTab::on_redirected(QUrl uri, bool is_permanent)
                 question
             );
             if(answer != QMessageBox::Yes) {
-                setErrorMessage(QString(tr("Redirection to %1 cancelled by user")).arg(uri.toString()));
+                setErrorMessage(tr("Redirection to %1 cancelled by user").arg(uri.toString()));
                 return;
             }
         }
@@ -958,7 +958,7 @@ void BrowserTab::on_redirected(QUrl uri, bool is_permanent)
         }
         else
         {
-            setErrorMessage(QString(tr("Redirection to %1 failed")).arg(uri.toString()));
+            setErrorMessage(tr("Redirection to %1 failed").arg(uri.toString()));
         }
     }
 }
@@ -967,7 +967,7 @@ void BrowserTab::setErrorMessage(const QString &msg)
 {
     this->is_internal_location = true;
     this->on_requestComplete(
-        QString(tr("An error happened:\r\n%0")).arg(msg).toUtf8(),
+        tr("An error happened:\r\n%0").arg(msg).toUtf8(),
         "text/plain charset=utf-8");
 
     this->updateUI();
@@ -1191,16 +1191,16 @@ void BrowserTab::on_text_browser_anchorClicked(const QUrl &url, bool open_in_new
         {
             if (not QDesktopServices::openUrl(url))
             {
-                QMessageBox::warning(this, "Kristall", QString(tr("Failed to start system URL handler for\r\n%1")).arg(real_url.toString()));
+                QMessageBox::warning(this, "Kristall", tr("Failed to start system URL handler for\r\n%1").arg(real_url.toString()));
             }
         }
         else if (support == ProtocolSetup::Disabled)
         {
-            QMessageBox::warning(this, "Kristall", QString(tr("The requested url uses a scheme that has been disabled in the settings:\r\n%1")).arg(real_url.toString()));
+            QMessageBox::warning(this, "Kristall", tr("The requested url uses a scheme that has been disabled in the settings:\r\n%1").arg(real_url.toString()));
         }
         else
         {
-            QMessageBox::warning(this, "Kristall", QString(tr("The requested url cannot be processed by Kristall:\r\n%1")).arg(real_url.toString()));
+            QMessageBox::warning(this, "Kristall", tr("The requested url cannot be processed by Kristall:\r\n%1").arg(real_url.toString()));
         }
     }
 }
@@ -1690,7 +1690,7 @@ void BrowserTab::on_text_browser_customContextMenuRequested(const QPoint pos)
                 if (!QDesktopServices::openUrl(real_url))
                 {
                     QMessageBox::warning(this, "Kristall",
-                        QString(tr("Failed to start system URL handler for\r\n%1")).arg(real_url.toString()));
+                        tr("Failed to start system URL handler for\r\n%1").arg(real_url.toString()));
                 }
             });
         }

--- a/src/dialogs/certificatemanagementdialog.cpp
+++ b/src/dialogs/certificatemanagementdialog.cpp
@@ -62,7 +62,7 @@ void CertificateManagementDialog::on_certificates_selected(QModelIndex const& in
         this->ui->cert_common_name->setText(cert.certificate.subjectInfo(QSslCertificate::CommonName).join(", "));
         this->ui->cert_expiration_date->setDateTime(cert.certificate.expiryDate());
         auto days = QDateTime::currentDateTime().daysTo(cert.certificate.expiryDate());
-        this->ui->cert_livetime->setText(QString(tr("%1 day","%1 days",days)).arg(days));
+        this->ui->cert_livetime->setText(tr("%1 day","%1 days", days).arg(days));
         this->ui->cert_fingerprint->setPlainText(toFingerprintString(cert.certificate));
         this->ui->cert_notes->setPlainText(cert.user_notes);
 
@@ -130,7 +130,7 @@ void CertificateManagementDialog::on_delete_cert_button_clicked()
         auto answer = QMessageBox::question(
             this,
             tr("Kristall"),
-            QString(tr("Do you want to delete the group '%1'")).arg(group_name)
+            tr("Do you want to delete the group '%1'").arg(group_name)
         );
         if(answer != QMessageBox::Yes)
             return;

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -663,7 +663,7 @@ void SettingsDialog::on_preset_new_clicked()
     bool override = false;
     if(this->predefined_styles.contains(name))
     {
-        auto response = QMessageBox::question(this, "Kristall", QString(tr("A style with the name '%1' already exists! Replace?")).arg(name));
+        auto response = QMessageBox::question(this, "Kristall", tr("A style with the name '%1' already exists! Replace?").arg(name));
         if(response != QMessageBox::Yes)
             return;
         override = true;
@@ -683,7 +683,7 @@ void SettingsDialog::on_preset_save_clicked()
     if(name.isEmpty())
         return;
 
-    auto response = QMessageBox::question(this, "Kristall", QString(tr("Do you want to override the style '%1'?")).arg(name));
+    auto response = QMessageBox::question(this, "Kristall", tr("Do you want to override the style '%1'?").arg(name));
     if(response != QMessageBox::Yes)
         return;
 
@@ -697,7 +697,7 @@ void SettingsDialog::on_preset_load_clicked()
     if(name.isEmpty())
         return;
 
-    auto response = QMessageBox::question(this, "Kristall", QString(tr("Do you want to load the style '%1'?\r\nThis will discard all currently set up values!")).arg(name));
+    auto response = QMessageBox::question(this, "Kristall", tr("Do you want to load the style '%1'?\r\nThis will discard all currently set up values!").arg(name));
     if(response != QMessageBox::Yes)
         return;
 
@@ -763,7 +763,7 @@ void SettingsDialog::on_preset_import_clicked()
     bool override = false;
     if(this->predefined_styles.contains(name))
     {
-        auto response = QMessageBox::question(this, "Kristall", QString(tr("Do you want to override the style '%1'?")).arg(name));
+        auto response = QMessageBox::question(this, "Kristall", tr("Do you want to override the style '%1'?").arg(name));
         if(response != QMessageBox::Yes)
             return;
         override = true;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -265,7 +265,7 @@ void MainWindow::updateWindowTitle()
         this->setWindowTitle(tr("Kristall"));
         return;
     }
-    this->setWindowTitle(QString(tr("%0 - %1")).arg(tab->page_title, tr("Kristall")));
+    this->setWindowTitle(tr("%0 - %1").arg(tab->page_title, tr("Kristall")));
 }
 
 void MainWindow::setUiDensity(UIDensity density, bool previewing)
@@ -574,7 +574,7 @@ void MainWindow::setFileStatus(const DocumentStats &stats)
         this->file_size->setText(IoUtil::size_human(stats.file_size));
         this->file_cached->setText(stats.loaded_from_cache ? tr("(cached)") : "");
         this->file_mime->setText(stats.mime_type.toString(false));
-        this->load_time->setText(QString(tr("%1 ms")).arg(stats.loading_time));
+        this->load_time->setText(tr("%1 ms").arg(stats.loading_time));
     } else {
         this->file_size->setText("");
         this->file_cached->setText("");

--- a/src/protocols/filehandler.cpp
+++ b/src/protocols/filehandler.cpp
@@ -35,7 +35,7 @@ bool FileHandler::startRequest(const QUrl &url, RequestOptions options)
         // URL points to directory - we create Gemtext
         // page which lists contents of directory.
         QString page;
-        page += QString(tr("# Index of %1\n")).arg(url.path());
+        page += tr("# Index of %1\n").arg(url.path());
 
         auto filters = QDir::Dirs | QDir::Files | QDir::NoDot;
         if (kristall::globals().options.show_hidden_files_in_dirs) filters |= QDir::Hidden;
@@ -45,7 +45,7 @@ bool FileHandler::startRequest(const QUrl &url, RequestOptions options)
         for (unsigned i = 0; i < dir.count(); ++i)
         {
             // Add link to page.
-            page += QString(tr("=> file://%1 %2\n"))
+            page += tr("=> file://%1 %2\n")
                 .arg(QUrl(dir.filePath(dir[i])).toString(QUrl::FullyEncoded),
                 dir[i]);
         }


### PR DESCRIPTION
We don't need to wrap tr() with QString, because it returns QString anyway. Although it doesn't change the binary size (mostly because compilers were smart to remove that already), it helps to make the code a little bit cleaner.

It's a somewhat continuation of c740189, but I thought back then it happened only there, so now I've removed it from all places.