### PR TITLE
main.cpp: support sessions when multiple users have opened Kristall

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,7 +148,13 @@ MainWindow * getFocusedAppWindow()
 // the same machine.
 namespace ipc
 {
-    static char const * socket_name = "net.random-projects.kristall";
+    static const QString socket_name =
+#ifdef Q_OS_UNIX
+        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + "/"
+#elif defined Q_OS_WIN32
+        qEnvironmentVariable("USERNAME") + "-"
+#endif
+        "net.random-projects.kristall";
 
     struct Message
     {


### PR DESCRIPTION
Before this change, only the first user who had opened kristall had working ipc.

The easiest fix was to prepend an username to the socket and that's exactly what it does on Windows.

On Linux and other UNIX systems, we could do that too, but I came up with a bit different approach. I didn't like the fact that Qt puts sockets in /tmp, but luckily we can provide the full path for the socket (Windows uses pipes, so that's why it has its own case). I've changed it to put sockets in the runtime directory, because it's designed for that type of files and it's user-specific, so we don't even have to prepend the username to it.

---

I couldn't test that on Windows but I have crossed fingers it works as intended.