### PR TITLE
Push lazy-loaded links to the history

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -195,7 +195,7 @@ void BrowserTab::navigateTo(const QUrl &url, PushToHistory mode, RequestFlags fl
     this->successfully_loaded = false;
     this->timer.start();
 
-    if(not this->startRequest(url, ProtocolHandler::Default, flags)) {
+    if(!this->lazy_loading && not this->startRequest(url, ProtocolHandler::Default, flags)) {
         QMessageBox::critical(this, tr("Kristall"), tr("Failed to execute request to %1").arg(url.toString()));
         return;
     }
@@ -263,6 +263,7 @@ void BrowserTab::scrollToAnchor(QString const &anchor)
 
 void BrowserTab::reloadPage()
 {
+    lazy_loading = false;
     if (current_location.isValid())
         this->navigateTo(this->current_location, DontPush, RequestFlags::DontReadFromCache);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -169,10 +169,8 @@ BrowserTab * MainWindow::addNewTab(bool focus_new, QUrl const & url, bool lazylo
         tab->current_location = url;
         tab->lazy_loading = true;
     }
-    else
-    {
-        tab->navigateTo(url, BrowserTab::PushImmediate);
-    }
+
+    tab->navigateTo(url, BrowserTab::PushImmediate);
 
     if (!defaultTitle.isEmpty())
     {
@@ -387,7 +385,6 @@ void MainWindow::on_browser_tabs_currentChanged(int index)
             if (tab->lazy_loading)
             {
                 tab->reloadPage();
-                tab->lazy_loading = false;
             }
 
             this->setRequestState(tab->request_state);


### PR DESCRIPTION
When lazy-loaded links were making a new tab, they wasn't calling `tab->navigateTo(url, BrowserTab::PushImmediate)`. What's important is only it can push urls to the history and making a new function just for that seemed like it'd just complicate things.

So I've changed it to call `tab->navigateTo()` on every loading type. Unfortunately, that fixed our issue partly. Sure, links are now put into the history, but lazy-loaded tabs stopped being lazy-loaded anymore. Moreover, they were also reloading a page on first tab switch.

So I've made also a check that stops requesting lazy-loaded urls, which made lazy-loading work as intended again, and moved the unsetting lazy-loaded boolean on reload instead of right after it to be able to request the file, which finally...

Closes: #214