### PR TITLE
doc/gen-man.sh: make sed command portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ doc/kristall.1
 *~
 *.autosave
 *.a
+*.bak
 *.core
 *.moc
 *.o

--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -46,7 +46,7 @@ cp "$man_head" "$man_output"
 
 # Insert last modified date (use last-modified date of help.gemini)
 last_modified=$(date -r "$gemtext_in" +"%F")
-sed -i "$man_output" -e 's#\$(DATE)#'"$last_modified"'#g'
+sed -i'.bak' -e 's#\$(DATE)#'"$last_modified"'#g' "$man_output"
 
 # Some pre-processing before giving our gemtext to the awk script.
 gem_in=$(


### PR DESCRIPTION
usage of the "-i" feature of sed is not entirely portable across
different operating systems. -i has an optional extension to save
a backup of the edited file, and different systems parse this option
in a different manner.

the sed in GNU, busybox, NetBSD, and OpenBSD expects the argument
to be immediately after, like `-i.bak`, if it is present.

the sed in macOS and FreeBSD expects the argument to follow after
a space, like `-i .bak`, but will accept the `-i.bak` form as well.

the issue is that when no backup is specified, the first requires
just `-i`, where the second requires `-i ''`. the easiest way around
this is to just add a backup, which is what i chose to do here. i
also added the .bak extension to the .gitignore.

additionally, all aforementioned seds except for GNU usually require the file
to be the final argument, and will not accept it between other options.