### PR TITLE
doc/gen-man.sh: head and tail +/- syntax is not portable

### DIFF
--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -54,8 +54,7 @@ gem_in=$(
     cat "$gemtext_in" |
 
     # Strip a few lines from beginning/end of file.
-    tail -n +9 |
-    head -n -9 |
+    nl | awk 'FNR > 9' | sort -nr | awk 'FNR > 9' | sort -n | cut -f 2- |
 
     # First expression replaces all [Text like this] with bold text.
     # Second expression replaces text like *This* or _this_ with italic text.


### PR DESCRIPTION
the + and - syntax on head and tail are only present, as far as i know,
in GNU coreutils, and are not present on any other UNIX or BSD systems.

this patch replaces those with a more portable processing chain, which
is tested to work on GNU coreutils, NetBSD, macOS, and busybox.