### PR TITLE
Fix building on macOS/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,14 @@ QMAKE_COMMAND := qmake
 # QMAKE_COMMAND := /usr/bin/qmake-qt5
 
 UNAME := $(shell uname)
+UNAME_M := $(shell uname -m)
 # Homebrew on macOS does not link Qt5 into the system path.
 ifeq ($(UNAME),Darwin)
-	HOMEBREW_PATH=export PATH="$(PATH):/usr/local/opt/qt/bin";
+	ifeq ($(UNAME_M),arm64)
+		HOMEBREW_PATH=export PATH="$(PATH):/opt/homebrew/opt/qt/bin";
+	else
+		HOMEBREW_PATH=export PATH="$(PATH):/usr/local/opt/qt/bin";
+	endif
 endif
 
 kristall: build/kristall

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -55,11 +55,19 @@ win32-g++ {
 
 macx {
     # Homebrew include paths
-    INCLUDEPATH += /usr/local/opt/qt/include
-    LIBS += -L/usr/local/opt/qt/lib
+    contains(QMAKE_HOST.arch, arm.*):{
+        INCLUDEPATH += /opt/homebrew/opt/qt/include
+        LIBS += -L/opt/homebrew/opt/qt/lib
+    
+        INCLUDEPATH += /opt/homebrew/opt/openssl/include
+        LIBS += -L/opt/homebrew/opt/openssl/lib
+    } else {
+        INCLUDEPATH += /usr/local/opt/qt/include
+        LIBS += -L/usr/local/opt/qt/lib
 
-    INCLUDEPATH += /usr/local/opt/openssl/include
-    LIBS += -L/usr/local/opt/openssl/lib
+        INCLUDEPATH += /usr/local/opt/openssl/include
+        LIBS += -L/usr/local/opt/openssl/lib
+    }
 
     ICON = icons/AppIcon.icns
 }


### PR DESCRIPTION
Homebrew installs to a different directory on macOS/arm64.

this adds checks in the Makefile and in kristall.pro, and sets
the correct paths to Homebrew depending on whether the build is
targeting arm64 or not.