### PR TITLE
Fix macos build for m1 - macos 11 & current homebrew

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -142,6 +142,17 @@ Use QtCreator to build `./src/kristall.pro` with default settings.
     - `openssl_devel` (should be preinstalled)
 2. Use `make` to build the executable
 
+#### Haiku x86
+
+1. Install the following packages with `pkgman`:
+    - `qt5_x86`
+    - `qt5_x86_devel`
+    - `qt5_x86_tools`
+    - `libiconv_x86_devel`
+    - `openssl_x86_devel` (should be preinstalled)
+2. run `setarch x86`
+3. Use `make` to build the executable
+
 ## Manual Installation
 
 ### Unix / XDG

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ UNAME_M := $(shell uname -m)
 # Homebrew on macOS does not link Qt5 into the system path.
 ifeq ($(UNAME),Darwin)
 	ifeq ($(UNAME_M),arm64)
-		HOMEBREW_PATH=export PATH="$(PATH):/opt/homebrew/opt/qt/bin";
+		HOMEBREW_PATH=export PATH="$(PATH):/opt/homebrew/opt/qt5/bin";
 	else
 		HOMEBREW_PATH=export PATH="$(PATH):/usr/local/opt/qt/bin";
 	endif

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -34,6 +34,9 @@ QMAKE_CXXFLAGS += -Wno-unused-parameter -Werror=return-type
 QMAKE_CXXFLAGS += -std=c++17
 CONFIG += c++17
 
+# avoid x86 OOM errors
+CONFIG += resources_big
+
 win32-msvc {
     # message("Use windows/msvc build")
     QMAKE_CFLAGS -= -Wno-unused-parameter

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -59,8 +59,8 @@ win32-g++ {
 macx {
     # Homebrew include paths
     contains(QMAKE_HOST.arch, arm.*):{
-        INCLUDEPATH += /opt/homebrew/opt/qt/include
-        LIBS += -L/opt/homebrew/opt/qt/lib
+        INCLUDEPATH += /opt/homebrew/opt/qt5/include
+        LIBS += -L/opt/homebrew/opt/qt5/lib
     
         INCLUDEPATH += /opt/homebrew/opt/openssl/include
         LIBS += -L/opt/homebrew/opt/openssl/lib


### PR DESCRIPTION
It is a very small difference, qt5 instead of qt in some paths. Maybe I am wrong about this being necessary to merge, but builds properly for me if I make these changes vs no changes. 