### PR TITLE
Apply Debian patches

### DIFF
--- a/doc/kristall-head.man
+++ b/doc/kristall-head.man
@@ -2,7 +2,7 @@
 .\" Kristall man page
 .\"
 .
-.TH KRISTALL 1 $(DATE) Unix "User manuals"
+.TH KRISTALL 1 Unix "User manuals"
 .SH NAME
 .PP
 .B kristall

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -24,11 +24,14 @@ DEFINES += KRISTALL_VERSION="\"$(shell cd $$PWD; git describe --tags)\""
 # Initialize build flags from environment variables.
 QMAKE_CFLAGS   *= $$(CFLAGS)
 QMAKE_CXXFLAGS *= $$(CXXFLAGS)
-QMAKE_CPPFLAGS *= $$(CPPFLAGS)
 QMAKE_LFLAGS   *= $$(LDFLAGS)
 
 QMAKE_CFLAGS += -Wno-unused-parameter -Werror=return-type
 QMAKE_CXXFLAGS += -Wno-unused-parameter -Werror=return-type
+
+# qmake does not use QMAKE_CPPFLAGS, this is a hack to include it
+QMAKE_CXXFLAGS += $$(CPPFLAGS)
+QMAKE_CFLAGS   += $$(CPPFLAGS)
 
 # Enable C++17
 QMAKE_CXXFLAGS += -std=c++17


### PR DESCRIPTION
Hi, as mentioned in #244, 83c9cc5a6b65952f1ef0534b87e8fc62a51b2f05 fixes the build reproducibility problem and e1311b8f393a33c16aa9310f3354157e6da48141 fixes the build flags problem.

Appending the CPPFLAGS to CFLAGS and CXXFLAGS builds fine in debian and debian derivatives. Since 7074170f69fdf8b4d41954ab42d48fea971293b3 the flags are expanded for all OSs by qmake, so I don't think it'll be a problem. Though I don't have windows or mac machines to try it out (if someone has and could check, it'd be awesome).