### PR TITLE
Fix typo and update building documentation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -34,11 +34,11 @@ make
  - Additionally, the following must be exported for qmake: `export QMAKESPEC=freebsd-clang`
 
 #### Notes for Ubuntu and Debian
-Supported Versions:
+- Supported Versions:
   - Ubuntu: 18.04, 20.04
   - Debian: 10, 11, 12 (TBA)
 
-Unsupported Versions
+- Unsupported Versions
   - Ubuntu: 16.04
   - Debian: 9
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -33,9 +33,14 @@ make
   - `git` - optional, for cloning from CLI
  - Additionally, the following must be exported for qmake: `export QMAKESPEC=freebsd-clang`
 
-#### Notes for Ubuntu
-Supported Versions: 18.04, 20.04
-Unsupported Versions: 16.04
+#### Notes for Ubuntu and Debian
+Supported Versions:
+  - Ubuntu: 18.04, 20.04
+  - Debian: 10, 11, 12 (TBA)
+
+Unsupported Versions
+  - Ubuntu: 16.04
+  - Debian: 9
 
 - Required packages
   - `qt5-default`
@@ -47,7 +52,9 @@ Unsupported Versions: 16.04
   - `make`
   - `g++`
 
-These notes are probably also correct for Debian (someone please verify)
+- Additional packages (to use dynamic libraries)
+  - `libcmark-dev`
+  - `libgumbo-dev`
 
 #### Notes for Fedora 32 (and probably other recent versions)
 In the small `Makefile` mentioned above, comment out the line:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -83,6 +83,7 @@ This is because Fedora has a different naming scheme for the qmake executable.
   - `qt5-multimedia`
   - `qt5-svg`
   - `openssl` or `libressl`
+  - `qt5-tools`
 
 #### Notes on void linux
 - set env variable `QT_SELECT=5`

--- a/src/about/help.gemini
+++ b/src/about/help.gemini
@@ -178,7 +178,7 @@ This is a purely cosmetic feature that may aid in readability.
 
 [Hidden files in file:// directories] determines whether hidden files will display in local directory listings (i.e file:// URLs which do not point to a specific document but rather a directory).
 
-[Strip <nav> from HTML pages] allows you to remove the <nav> tag from HTML pages. This might make certain pages more readable, others completly unusable.
+[Strip <nav> from HTML pages] allows you to remove the <nav> tag from HTML pages. This might make certain pages more readable, others completely unusable.
 
 ### Cache
 


### PR DESCRIPTION
Hi, the 3 commits do the following:
- ace7c440644655a74d4caf45ea05e2d3d468448c fixes a typo in `help.gemini`;
- 101ad24c91f8131b3d348eda214486851c7951d2 adds info about Debian;
- 6306b51ee09fc3da4d59d1ed0b2850b30a9276c9 fixes #262 by adding a required package in Arch.