### PR TITLE
Fix media player stuttering

### DIFF
--- a/src/widgets/mediaplayer.cpp
+++ b/src/widgets/mediaplayer.cpp
@@ -18,7 +18,8 @@ MediaPlayer::MediaPlayer(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::MediaPlayer),
     media_stream(),
-    player()
+    player(),
+    manual_seek(false)
 {
     ui->setupUi(this);
 
@@ -51,7 +52,9 @@ MediaPlayer::MediaPlayer(QWidget *parent) :
 
     connect(&this->player, &QMediaPlayer::positionChanged, this, &MediaPlayer::on_media_positionChanged);
 
-    connect(this->ui->media_progress, &QSlider::valueChanged, &this->player, &QMediaPlayer::setPosition);
+    connect(this->ui->media_progress, &QSlider::valueChanged, this, &MediaPlayer::on_seekChanged);
+    connect(this->ui->media_progress, &QSlider::sliderPressed, this, &MediaPlayer::on_seekPressed);
+    connect(this->ui->media_progress, &QSlider::sliderReleased, this, &MediaPlayer::on_seekReleased);
 }
 
 MediaPlayer::~MediaPlayer()
@@ -132,3 +135,20 @@ void MediaPlayer::on_media_playbackChanged(QMediaPlayer::PlaybackState status)
     );
 }
 #endif
+
+void MediaPlayer::on_seekChanged(qint64 pos)
+{
+    if (this->manual_seek) {
+        player.setPosition(pos);
+    }
+}
+
+void MediaPlayer::on_seekPressed()
+{
+    this->manual_seek = true;
+}
+
+void MediaPlayer::on_seekReleased()
+{
+    this->manual_seek = false;
+}

--- a/src/widgets/mediaplayer.hpp
+++ b/src/widgets/mediaplayer.hpp
@@ -28,6 +28,10 @@ private slots:
 
     void on_mute_button_clicked(bool checked);
 
+    void on_seekChanged(qint64 pos);
+    void on_seekPressed();
+    void on_seekReleased();
+
 private: // slots
     void on_media_positionChanged(qint64 pos);
 
@@ -42,6 +46,7 @@ private:
     QBuffer media_stream;
     QString mime;
     QMediaPlayer player;
+    bool manual_seek;
 };
 
 #endif // MEDIAPLAYER_HPP


### PR DESCRIPTION
Only call setPosition() on the QMediaPlayer object when the user has manually dragged the slider position slider.

Otherwise the slider and player will call each other, probably causing a feedback loop which causes stuttering.