### PR TITLE
Fix crash when closing gopher tab during content loading

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -176,6 +176,7 @@ BrowserTab::BrowserTab(MainWindow *mainWindow) : QWidget(nullptr),
 
 BrowserTab::~BrowserTab()
 {
+    this->current_handler->cancelRequest();
     delete ui;
 }
 


### PR DESCRIPTION
This only seems to happen in the GopherClient. It's easiest to reproduce the crash when downloading a large file, and closing the tab before the download has completed.

I think this happens because when the BrowserTab is closed it deletes the client, but the client has still got it's signals connected. So when the GopherClient [emits 'requestProgress'](https://github.com/entropic77/kristall/blob/fix-crash-on-close-tab/src/protocols/gopherclient.cpp#L115), the deleted BrowserTab's `on_requestProgress` will be called, where it calls [kristall::globals()](https://github.com/entropic77/kristall/blob/fix-crash-on-close-tab/src/browsertab.cpp#L1268), which seems to cause the crash.

Fixed by calling `this->current_handler->cancelRequest();` in the [BrowserTab destructor](https://github.com/entropic77/kristall/blob/fix-crash-on-close-tab/src/browsertab.cpp#L180), which will cause clients to [stop emitting 'requestProgress'](https://github.com/entropic77/kristall/blob/fix-crash-on-close-tab/src/protocols/gopherclient.cpp#L114).
