### PR TITLE
Allow middle-click to open new tab when text is selected

### DIFF
--- a/src/widgets/kristalltextbrowser.cpp
+++ b/src/widgets/kristalltextbrowser.cpp
@@ -48,6 +48,9 @@ KristallTextBrowser::KristallTextBrowser(QWidget *parent) :
 void KristallTextBrowser::mouseReleaseEvent(QMouseEvent *event)
 {
     if(event->button() == Qt::MiddleButton) {
+        // Deselect any selection. Otherwise the click won't register.
+        setTextCursor(cursorForPosition(event->pos()));
+
         // Fake a middle-click event here
         QMouseEvent fake_event {
             event->type(),


### PR DESCRIPTION
If text is selected, middle-click will not be forwarded to the function that opens the link in a new tab. So this change will deselect any selected text before trying to open a new tab.

Fixes #253