### PR TITLE
Focus browsing area after page is loaded

### DIFF
--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -214,6 +214,8 @@ void BrowserTab::navigateTo(const QUrl &url, PushToHistory mode, RequestFlags fl
     }
 
     this->updateUI();
+
+    this->ui->text_browser->setFocus();
 }
 
 void BrowserTab::navigateBack(const QModelIndex &history_index)


### PR DESCRIPTION
This change allows the user to start scrolling with the keyboard instantly, without having to focus the browsing area first, after a page has loaded.

This happens for example when opening a new tab, and when entering an address manually.