### PR TITLE
Fix manpage generation in sh shell and gen-man.sh cleanup

### DIFF
--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -44,10 +44,6 @@ fi
 # Write the head to the output file.
 cp "$man_head" "$man_output"
 
-# Insert last modified date (use last-modified date of help.gemini)
-last_modified=$(date -r "$gemtext_in" +"%F")
-sed -i'.bak' -e 's#\$(DATE)#'"$last_modified"'#g' "$man_output"
-
 # Some pre-processing before giving our gemtext to the awk script.
 gem_in=$(
     # Read input file

--- a/doc/gen-man.sh
+++ b/doc/gen-man.sh
@@ -59,8 +59,8 @@ gem_in=$(
     # First expression replaces all [Text like this] with bold text.
     # Second expression replaces text like *This* or _this_ with italic text.
     sed -E \
-      -e 's#\[([^]]*)\]#\\fB\1\\fR#g' \
-      -e 's#(^|[.,!? ]+)[*_]([^*_ ]+[^*_]+[^*_ ]+)[*_]($|[.,!? ])#\1\\fI\2\\fR\3#g'
+      -e 's#\[([^]]*)\]#\\\\fB\1\\\\fR#g' \
+      -e 's#(^|[.,!? ]+)[*_]([^*_ ]+[^*_]+[^*_ ]+)[*_]($|[.,!? ])#\1\\\\fI\2\\\\fR\3#g'
 )
 
 # Convert gemtext to man format


### PR DESCRIPTION
3a015f7 fix a escape char problem in sh (#274)  and 710a5fc remove unused logic from gen-man script.