### PR TITLE
Fixes #279: Updates dialog with active search engines

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -294,6 +294,7 @@ void SettingsDialog::setOptions(const GenericSettings &options)
     this->ui->search_engine->lineEdit()->setPlaceholderText(tr("URL with '%1' in place of query"));
     this->ui->search_engine->addItem("gemini://kennedy.gemi.dev/search?%1");
     this->ui->search_engine->addItem("gemini://tlgs.one/search?%1");
+    this->ui->search_engine->addItem("gemini://geminispace.info/search?%1");
     this->ui->search_engine->addItem("gopher://gopher.floodgap.com:70/7/v2/vs?%1");
     this->ui->search_engine->setCurrentText(search);
 

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -292,9 +292,8 @@ void SettingsDialog::setOptions(const GenericSettings &options)
     this->ui->search_engine->clear();
     QString search = this->current_options.search_engine;
     this->ui->search_engine->lineEdit()->setPlaceholderText(tr("URL with '%1' in place of query"));
-    this->ui->search_engine->addItem("gemini://geminispace.info/search?%1");
-    this->ui->search_engine->addItem("gemini://gus.guru/search?%1");
-    this->ui->search_engine->addItem("gemini://houston.coder.town/search?%1");
+    this->ui->search_engine->addItem("gemini://kennedy.gemi.dev/search?%1");
+    this->ui->search_engine->addItem("gemini://tlgs.one/search?%1");
     this->ui->search_engine->addItem("gopher://gopher.floodgap.com:70/7/v2/vs?%1");
     this->ui->search_engine->setCurrentText(search);
 


### PR DESCRIPTION
Fixes #279 By adding Kennedy and TLGS as search engines, removing GUS and Houston which no longer exist