### PR TITLE
Replace `QInputDialog` with custom dialog for queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ set(PROJECT_SOURCES
     src/widgets/ssltrusteditor.cpp
     src/widgets/favouritepopup.cpp
     src/widgets/favouritebutton.cpp
+    src/widgets/querydialog.ui
+    src/widgets/querydialog.cpp
     src/cachehandler.cpp
     src/widgets/searchbox.cpp
     src/browsertab.ui

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -25,6 +25,7 @@
 #include "kristall.hpp"
 #include "widgets/favouritepopup.hpp"
 #include "widgets/searchbox.hpp"
+#include "widgets/querydialog.hpp"
 
 #include <cassert>
 #include <QTabWidget>
@@ -867,10 +868,8 @@ void BrowserTab::on_inputRequired(const QString &query, const bool is_sensitive)
 {
     this->network_timeout_timer.stop();
 
-    QInputDialog dialog{this};
+    QueryDialog dialog(this);
 
-    dialog.setInputMode(QInputDialog::TextInput);
-    dialog.setOption(QInputDialog::UsePlainTextEditForTextInput);
     dialog.setLabelText(query);
     if (is_sensitive) dialog.setTextEchoMode(QLineEdit::Password);
 

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -158,7 +158,8 @@ SOURCES += \
     widgets/favouritepopup.cpp \
     widgets/favouritebutton.cpp \
     cachehandler.cpp \
-    widgets/searchbox.cpp
+    widgets/searchbox.cpp \
+    widgets/querydialog.cpp
 
 HEADERS += \
     ../lib/luis-l-gist/interactiveview.hpp \
@@ -206,6 +207,7 @@ HEADERS += \
     widgets/ssltrusteditor.hpp \
     widgets/favouritepopup.hpp \
     widgets/favouritebutton.hpp \
+    widgets/querydialog.hpp \
     cachehandler.hpp \
     widgets/searchbox.hpp
 
@@ -218,7 +220,8 @@ FORMS += \
   dialogs/settingsdialog.ui \
   mainwindow.ui \
   widgets/mediaplayer.ui \
-  widgets/ssltrusteditor.ui
+  widgets/ssltrusteditor.ui \
+  widgets/querydialog.ui
 
 CONFIG += lrelease embed_translations
 

--- a/src/widgets/querydialog.cpp
+++ b/src/widgets/querydialog.cpp
@@ -1,0 +1,30 @@
+#include "widgets/querydialog.hpp"
+
+QueryDialog::QueryDialog(QWidget *parent) :
+    QDialog(parent),
+    mode(QLineEdit::Normal)
+{
+    ui.setupUi(this);
+    ui.lineEdit->setVisible(false);
+}
+
+void QueryDialog::setLabelText(const QString &text)
+{
+    ui.query->setText(text);
+}
+
+void QueryDialog::setTextEchoMode(QLineEdit::EchoMode mode)
+{
+    ui.text->setVisible(mode == QLineEdit::Normal);
+    ui.lineEdit->setVisible(mode != QLineEdit::Normal);
+    ui.lineEdit->setEchoMode(mode);
+    this->mode = mode;
+}
+
+QString QueryDialog::textValue()
+{
+    if (mode == QLineEdit::Normal)
+        return ui.text->toPlainText();
+
+    return ui.lineEdit->text();
+}

--- a/src/widgets/querydialog.hpp
+++ b/src/widgets/querydialog.hpp
@@ -1,0 +1,20 @@
+#ifndef QUERYDIALOG_H
+#define QUERYDIALOG_H
+
+#include "ui_querydialog.h"
+#include <QDialog>
+#include <QLineEdit>
+#include <QString>
+
+class QueryDialog : public QDialog {
+public:
+    QueryDialog(QWidget *parent);
+    void setLabelText(const QString &text);
+    void setTextEchoMode(QLineEdit::EchoMode mode);
+    QString textValue();
+private:
+    Ui_QueryDialog ui;
+    QLineEdit::EchoMode mode;
+};
+
+#endif

--- a/src/widgets/querydialog.ui
+++ b/src/widgets/querydialog.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QueryDialog</class>
+ <widget class="QDialog" name="QueryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="query">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="text"/>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="lineEdit"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QueryDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QueryDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Recent commits allowed multi-line input while reusing the `QInputDialog` object already defined by Kristall. However, `QInputDialog` lacks a way to access its `QPlainTextEdit` directly, and therefore set the wrap mode.

Since `QInputDialog` does no wrapping, it is inconvenient for writing a long text (think of social media sites such as [BBS](gemini://bbs.geminispace.org) or [Station](gemini://station.martinrue.com)). Therefore, a custom `QDialog`-derived class, namely `QueryDialog`, has been provided.

### Notes

If data is sensitive (e.g.: passwords), `QueryDialog` hides its `QPlainTextEdit` and shows a `QLineEdit`, and vice versa.