### PR TITLE
`querydialog.ui`: Allow smaller dialog size

### DIFF
--- a/src/widgets/querydialog.ui
+++ b/src/widgets/querydialog.ui
@@ -10,14 +10,26 @@
     <height>240</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Dialog</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="query">
      <property name="text">
       <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Background

As the query label is determined by the remote server, it can be arbitrarily long. Therefore, it makes sense to enable word wrap so the dialog still fits on devices with smaller screens, such as mobile phones.

## Screenshots

### Before
![before](https://github.com/MasterQ32/kristall/assets/25252461/06a260f8-222f-4b8f-b463-8682c947303c)

### After
![after](https://github.com/MasterQ32/kristall/assets/25252461/621d5e9f-a362-4c91-95ee-f3f9daa9efae)
