### PR TITLE
Use QRegularExpression instead of QRegExp

### DIFF
--- a/src/cryptoidentity.cpp
+++ b/src/cryptoidentity.cpp
@@ -10,7 +10,11 @@ static QRegularExpression fromWildcardCaseInsensitive(QStringView pattern)
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     return QRegularExpression::fromWildcard(pattern, Qt::CaseInsensitive);
 #else
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     QString strPattern = QRegularExpression::wildcardToRegularExpression(pattern);
+#else
+    QString strPattern = QRegularExpression::wildcardToRegularExpression(pattern.toString());
+#endif
     return QRegularExpression(strPattern, QRegularExpression::CaseInsensitiveOption);
 #endif
 }

--- a/src/cryptoidentity.cpp
+++ b/src/cryptoidentity.cpp
@@ -1,8 +1,19 @@
 #include "cryptoidentity.hpp"
 
 #include <QUrl>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <cassert>
+
+static QRegularExpression fromWildcardCaseInsensitive(QStringView pattern)
+{
+    // Note: QRegularExpression converted from wildcard is anchored by default.
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    return QRegularExpression::fromWildcard(pattern, Qt::CaseInsensitive);
+#else
+    QString strPattern = QRegularExpression::wildcardToRegularExpression(pattern);
+    return QRegularExpression(strPattern, QRegularExpression::CaseInsensitiveOption);
+#endif
+}
 
 bool CryptoIdentity::isHostFiltered(const QUrl &url) const
 {
@@ -11,9 +22,9 @@ bool CryptoIdentity::isHostFiltered(const QUrl &url) const
 
     QString url_text = url.toString(QUrl::FullyEncoded);
 
-    QRegExp pattern { this->host_filter, Qt::CaseInsensitive, QRegExp::Wildcard };
+    QRegularExpression pattern = fromWildcardCaseInsensitive(this->host_filter);
 
-    return not pattern.exactMatch(url_text);
+    return not pattern.match(url_text).hasMatch();
 }
 
 bool CryptoIdentity::isAutomaticallyEnabledOn(const QUrl &url) const
@@ -25,7 +36,7 @@ bool CryptoIdentity::isAutomaticallyEnabledOn(const QUrl &url) const
 
     QString url_text = url.toString(QUrl::FullyEncoded);
 
-    QRegExp pattern { this->host_filter, Qt::CaseInsensitive, QRegExp::Wildcard };
+    QRegularExpression pattern = fromWildcardCaseInsensitive(this->host_filter);
 
-    return pattern.exactMatch(url_text);
+    return pattern.match(url_text).hasMatch();
 }


### PR DESCRIPTION
`QRegExp` is deprecated since Qt6 and needs the Core5Compat component to compile in Qt6.